### PR TITLE
Allow fp8 packing constants to be used in host constexpr contexts

### DIFF
--- a/include/common/base_types.cuh
+++ b/include/common/base_types.cuh
@@ -241,12 +241,12 @@ template<> struct packing<int4> {
     static __host__ __device__ inline constexpr int num() { return 4; }
 };
 template<> struct packing<fp8e4m3> {
-    static __device__ inline constexpr int num() { return 1; }
+    static __host__ __device__ inline constexpr int num() { return 1; }
     using unpacked_type = fp8e4m3;
     using packed_type = fp8e4m3_4;
 };
 template<> struct packing<fp8e4m3_4> {
-    static __device__ inline constexpr int num() { return 4; }
+    static __host__ __device__ inline constexpr int num() { return 4; }
     using unpacked_type = fp8e4m3;
     using packed_type = fp8e4m3_4;
 };


### PR DESCRIPTION
## Summary
- mark the fp8 and fp8_4 packing `num()` helpers as `__host__ __device__`
- this lets register-tile specializations compute `num_packed` on the host side, fixing the build failure triggered by fp8 kernels

## Testing
- make -C kernels/gemm/fp8fp32/FP8_4wave