### PR TITLE
Remove duplicate ceil_div implementation in 256_256_64_32_with32x16.cpp to fix ambiguous overload error

### DIFF
--- a/kernels/gemm/bf16fp32/mi350x/256_256_64_32_with32x16.cpp
+++ b/kernels/gemm/bf16fp32/mi350x/256_256_64_32_with32x16.cpp
@@ -21,10 +21,6 @@ using _gl_C = gl<bf16, -1, -1, -1, -1>;
 
 using G = kittens::group<NUM_WARPS>;
 
-__host__ __device__ inline int ceil_div(int a, int b) {
-  return (a + b - 1) / b;
-}
-
 struct micro_globals {
     _gl_A a;
     _gl_B b;


### PR DESCRIPTION
When building the kernel with HIPCC for CDNA4 (gfx950), the compiler reports an ambiguous call between the global ceil_div() defined in include/common/util.cuh, and the duplicate local definition in this .cpp file.