### PR TITLE
Align memcpy configuration with ST_A shared tile type

### DIFF
--- a/kernels/gemm/bf16fp32/mi350x/256_256_64_32_with16x32.cpp
+++ b/kernels/gemm/bf16fp32/mi350x/256_256_64_32_with16x32.cpp
@@ -105,8 +105,8 @@ void micro_tk(const micro_globals g) {
     int tic = 0;
     int toc = 1;
 
-    using T = typename st_bf<BLOCK_SIZE, K_STEP, st_32x16_s>::dtype;
-    constexpr int bytes_per_thread = st_32x16_s::template bytes_per_thread<T>();
+    using T = typename ST_A::dtype;
+    constexpr int bytes_per_thread = ST_A::underlying_subtile_bytes_per_thread;
     constexpr int bytes_per_memcpy = bytes_per_thread * NUM_THREADS;
     constexpr int memcpy_per_tile = BLOCK_SIZE * K_STEP * sizeof(T) / bytes_per_memcpy;
     uint32_t swizzled_offsets_A[memcpy_per_tile/2];


### PR DESCRIPTION
The behavior is unchanged, but the code becomes easier to understand:

(1) T is now taken from ST_A::dtype, rather than re‑spelling the same st_bf<...>::dtype alias.
(2) bytes_per_thread now uses ST_A::underlying_subtile_bytes_per_thread, keeping the memcpy granularity tied to the actual shared tile layout used in this kernel.

This makes the relationship between the shared tile definitions and the global‑to‑shared memcpy parameters explicit, and helps avoid future inconsistencies if the shared tile shape is updated.