### PR TITLE
Add missing CK url to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "analysis/blackwell/cutlass"]
 	path = analysis/blackwell/cutlass
 	url = https://github.com/NVIDIA/cutlass.git
+[submodule "analysis/baselines/composable_kernel"]
+	path = analysis/baselines/composable_kernel
+	url = https://github.com/ROCm/composable_kernel.git


### PR DESCRIPTION
- Otherwise `git submodule status` errors
```
fatal: No url found for submodule path 'analysis/baselines/composable_kernel' in .gitmodules
```