### PR TITLE
Optimize RMSNorm kernel with multi-row pipelining

### DIFF
--- a/kernels/rmsnorm/kernel.cpp
+++ b/kernels/rmsnorm/kernel.cpp
@@ -10,6 +10,8 @@ constexpr int D = 128;
 
 #define NUM_WORKERS (4) 
 #define NUM_THREADS (NUM_WORKERS*kittens::WARP_THREADS)
+#define ROWS_PER_WARP (8)
+static_assert(ROWS_PER_WARP % 2 == 0 && ROWS_PER_WARP >= 2);
 
 using G = kittens::group<NUM_WORKERS>;
 using namespace kittens;
@@ -25,42 +27,79 @@ template <int _N> struct rmsnorm_globals{
     gamma_gl gamma;
     float epsilon;
 
-    const int n_per_tile = NUM_WORKERS;
-    const int n_tile_size = N / n_per_tile;
+    static constexpr int n_per_tile = NUM_WORKERS * ROWS_PER_WARP;
+    static constexpr int n_tile_size = N / n_per_tile;
+    static_assert(N % n_per_tile == 0, "N must be divisible by NUM_WORKERS * ROWS_PER_WARP");
 
     dim3 grid() { return dim3(n_tile_size, B, 1); }
     dim3 block() { return dim3(NUM_THREADS); }
     size_t dynamic_shared_memory() { return 0; }
 }; 
 
+#define COMPUTE_X_ONLY(x_reg, x_reg_squared, _D, epsilon) \
+    do { \
+        mul(x_reg_squared, x_reg, x_reg); \
+        bf16 _x_var; \
+        sum(_x_var, x_reg_squared); \
+        float _var_f32 = __bfloat162float(_x_var) / float(_D); \
+        float _inv_rms_f32 = rsqrtf(_var_f32 + epsilon); \
+        bf16 _inv_rms = __float2bfloat16(_inv_rms_f32); \
+        mul(x_reg, x_reg, _inv_rms); \
+    } while(0)
+
 template<int _D>
 __global__ void rmsnorm_hk(
     const rmsnorm_globals<_D> g 
 ){
+    static constexpr int LOADS_PER_RV  = rv<bf16, _D>::outer_dim;
+    static constexpr int LOADS_PER_ROW = 2 * LOADS_PER_RV;
+    static constexpr int PIPELINE      = 2 * LOADS_PER_ROW;
+    static constexpr int WAIT_X        = PIPELINE - LOADS_PER_RV;
+    static constexpr int WAIT_GAMMA    = PIPELINE - LOADS_PER_ROW;
+    static constexpr int WAIT_X_LAST   = LOADS_PER_ROW - LOADS_PER_RV;
+    static_assert(PIPELINE <= 63, "pipeline depth exceeds vmcnt range");
+
     auto warpid = kittens::warpid();
     const int batch = blockIdx.y;
-    const int seq_start = blockIdx.x * g.n_per_tile;
-    const int seq_idx = seq_start + warpid; 
+    const int seq_start = blockIdx.x * g.n_per_tile + warpid * ROWS_PER_WARP;
 
-    rv<bf16 , _D> x_reg , gamma_reg , x_reg_squared;
+    rv<bf16, _D> x_reg_a, x_reg_b, gamma_reg_a, gamma_reg_b, x_reg_squared;
 
-    load(x_reg, g.x, {0, batch, seq_idx, 0});
-    load(gamma_reg , g.gamma, {0, batch, seq_idx, 0});
-    asm volatile("s_waitcnt vmcnt(0)"); 
+    load(x_reg_a, g.x, {0, batch, seq_start, 0});
+    load(gamma_reg_a, g.gamma, {0, batch, seq_start, 0});
+    load(x_reg_b, g.x, {0, batch, seq_start + 1, 0});
+    load(gamma_reg_b, g.gamma, {0, batch, seq_start + 1, 0});
 
-    mul(x_reg_squared, x_reg, x_reg);
+    #pragma unroll
+    for (int r = 0; r < ROWS_PER_WARP - 2; r += 2) {
+        asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_X));
+        COMPUTE_X_ONLY(x_reg_a, x_reg_squared, _D, g.epsilon);
+        asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_GAMMA));
+        mul(x_reg_a, x_reg_a, gamma_reg_a);
+        store(g.o, x_reg_a, {0, batch, seq_start + r, 0});
+        load(x_reg_a, g.x, {0, batch, seq_start + r + 2, 0});
+        load(gamma_reg_a, g.gamma, {0, batch, seq_start + r + 2, 0});
 
-    bf16 x_var;
-    sum(x_var, x_reg_squared);
+        asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_X));
+        COMPUTE_X_ONLY(x_reg_b, x_reg_squared, _D, g.epsilon);
+        asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_GAMMA));
+        mul(x_reg_b, x_reg_b, gamma_reg_b);
+        store(g.o, x_reg_b, {0, batch, seq_start + r + 1, 0});
+        load(x_reg_b, g.x, {0, batch, seq_start + r + 3, 0});
+        load(gamma_reg_b, g.gamma, {0, batch, seq_start + r + 3, 0});
+    }
 
-    float var_f32 = __bfloat162float(x_var) / float(_D);
-    float inv_rms_f32 = rsqrtf(var_f32 + g.epsilon);
-    bf16 inv_rms = __float2bfloat16(inv_rms_f32);
+    asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_X));
+    COMPUTE_X_ONLY(x_reg_a, x_reg_squared, _D, g.epsilon);
+    asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_GAMMA));
+    mul(x_reg_a, x_reg_a, gamma_reg_a);
+    store(g.o, x_reg_a, {0, batch, seq_start + ROWS_PER_WARP - 2, 0});
 
-    mul(x_reg, x_reg, inv_rms);
-    mul(x_reg, x_reg, gamma_reg); 
-
-    store(g.o, x_reg, {0, batch, seq_idx, 0});
+    asm volatile("s_waitcnt vmcnt(%0)" :: "n"(WAIT_X_LAST));
+    COMPUTE_X_ONLY(x_reg_b, x_reg_squared, _D, g.epsilon);
+    asm volatile("s_waitcnt vmcnt(0)");
+    mul(x_reg_b, x_reg_b, gamma_reg_b);
+    store(g.o, x_reg_b, {0, batch, seq_start + ROWS_PER_WARP - 1, 0});
 }
 
 


### PR DESCRIPTION
The RMSNorm kernel is memory-stall bound: each warp loads x and gamma, then stalls at `s_waitcnt vmcnt(0)` for ~400 cycles with only ~60 cycles of compute to show for it. This PR has each warp process 8 rows with double-buffered registers and split waitcnt, overlapping loads with compute. vmcnt wait counts are derived from `rv<bf16,_D>::outer_dim` at compile time.

Performance on MI300A (gfx942), BF16 B=16 D=128, hipEvent timing (200 warmup, 1000 iters):

| N | Original | Optimized | Speedup |
|---|----------|-----------|---------|
| 4096 | 0.0223 ms | 0.0208 ms | 1.07x |
| 8192 | 0.0421 ms | 0.0378 ms | 1.11x |
| 16384 | 0.0819 ms | 0.0719 ms | 1.14x |
| 65536 | 0.3980 ms | 0.3197 ms | 1.24x |

VGPRs go from 17 to 29 (occupancy 60% to 40%), but the latency hiding outweighs the lost TLP. `test_python.py` passes (max_diff=0.03125), LayerNorm and GEMM tests also pass. pybind11 interface unchanged.

Happy to adjust the approach if needed. Great project, thanks for open sourcing it!