### PR TITLE
Improve FP8 8-Wave GEMM Perf.

### DIFF
--- a/kernels/gemm/fp8fp32/FP8_4wave/4_wave.cu
+++ b/kernels/gemm/fp8fp32/FP8_4wave/4_wave.cu
@@ -999,8 +999,8 @@ int main() {
     constexpr int CUs = 256; // 256 threadblocks (1 outer iteration)
     
     // Timing parameters to keep total runtime reasonable  
-    constexpr int warmup_iters = 1000;
-    constexpr int timing_iters = 1000;
+    constexpr int warmup_iters = 500;
+    constexpr int timing_iters = 100;
 
     printf("Matrix dimensions: %dx%dx%d, CUs: %d\n", M, N, K, CUs);
     printf("Warmup iterations: %d, Timing iterations: %d\n\n", warmup_iters, timing_iters);

--- a/kernels/gemm/fp8fp32/FP8_8wave/8_wave.cu
+++ b/kernels/gemm/fp8fp32/FP8_8wave/8_wave.cu
@@ -417,8 +417,8 @@ int main() {
     constexpr int CUs = 256; // 256 threadblocks (1 outer iteration)
     
     // Timing parameters to keep total runtime reasonable
-    constexpr int warmup_iters = 1000;
-    constexpr int timing_iters = 1000;
+    constexpr int warmup_iters = 500;
+    constexpr int timing_iters = 100;
 
     printf("Matrix dimensions: %dx%dx%d, CUs: %d\n", M, N, K, CUs);
     printf("Warmup iterations: %d, Timing iterations: %d\n\n", warmup_iters, timing_iters);


### PR DESCRIPTION
This PR 

1. Eliminates register spilling in the FP8 8-Wave GEMM, leading to significant speedups across a wide range of matrix sizes
2. Fixes rotating buffer in the FP8 8-Wave benchmark script

<img width="1400" height="1000" alt="benchmark_data" src="https://github.com/user-attachments/assets/3944660f-d4b9-4e66-99b6-41e52535cb1a" />

Benchmark details
1. Docker container: rocm7.0_preview_pytorch_training_mi35x_beta
2. Hardware: AMD MI355X
3. Benchmark scripts: `kernels/gemm/fp8fp32/FP8_8wave/8_wave.cu`, `kernels/gemm/fp8fp32/FP8_4wave/4_wave.cu`
4. Params: warmup iters=1000, iters=1000, rotating buffer=512mib

| M=N=K | 8-Wave Before PR (avg. TFLOPS) | 8-Wave After PR (avg. TFLOPS) | 4-Wave (avg. TFLOPS) | 
| --- | --- | --- | --- |
| 3072 | 1103 | 1468 | 1454 |
| 4096 | 2010 | 2650  | 2651 |
| 5120 | 1536 | 2301 | 2209 |
| 6144 | 1557 | 2456 | 2337 |
| 7168 | 2540 | 2660 | 2484 |
| 8192 | 3152 | 3182 | 3185 |
| 9216 | 2771 | 2872 | 2838 |
| 10240 | 2864 | 2967 | 2975 |
| 11264 | 2929 | 3030 | 2860 |
| 12288 | 3030 | 3141 | 2927 |
| 14336 | 1598 | 3043 | 2996 |
| 16384 | 1655 | 3030 | 3023 |