### PR TITLE
add CDNA3 flash attention forward kernels

### DIFF
--- a/kernels/attn/gqa/Makefile
+++ b/kernels/attn/gqa/Makefile
@@ -1,0 +1,61 @@
+# CDNA3 Flash Attention Forward (Non-Causal) Makefile
+GPU_TARGET=CDNA3
+
+# ThunderKittens root (override with env)
+THUNDERKITTENS_ROOT ?= $(abspath ../../../)
+
+# Compile-time attention shape parameters
+ATTN_B     ?= 4
+ATTN_H     ?= 32
+ATTN_H_KV  ?= 8
+ATTN_N     ?= 1024
+
+# HIP variables
+ROCM_INSTALL_DIR := $(ROCM_PATH)
+HIP_INCLUDE_DIR  := $(ROCM_INSTALL_DIR)/include/hip
+ROCM_INCLUDE_DIR := $(ROCM_INSTALL_DIR)/include
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Compiler flags based on GPU target
+ifeq ($(GPU_TARGET),CDNA3)
+HIPFLAGS += -DKITTENS_CDNA3 --offload-arch=gfx942
+endif
+
+# Common flags
+CXX_STD   := c++20
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -I${THUNDERKITTENS_ROOT}/include -I$(ROCM_INCLUDE_DIR) -I$(HIP_INCLUDE_DIR)
+ILDFLAGS  :=
+ILDLIBS   :=
+
+CXXFLAGS := -w
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+# Pybind11
+ICXXFLAGS += $(shell python3 -m pybind11 --includes) $(shell python3-config --ldflags) -shared -fPIC
+ICXXFLAGS += -Rpass-analysis=kernel-resource-usage
+
+# Shape defines
+SHAPE_FLAGS = -DATTN_B=$(ATTN_B) -DATTN_H=$(ATTN_H) -DATTN_H_KV=$(ATTN_H_KV) -DATTN_N=$(ATTN_N)
+
+PYEXT := $(shell python3-config --extension-suffix)
+
+# Default target: build both D=128 and D=64
+all: attn_fwd attn_fwd_d64
+
+attn_fwd: kernel.cpp
+	$(HIPCXX) kernel.cpp $(HIPFLAGS) $(SHAPE_FLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) \
+	    -o attn_fwd$(PYEXT) 2>&1
+
+attn_fwd_d64: kernel_d64.cpp
+	$(HIPCXX) kernel_d64.cpp $(HIPFLAGS) $(SHAPE_FLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) \
+	    -o attn_fwd_d64$(PYEXT) 2>&1
+
+clean:
+	rm -f attn_fwd$(PYEXT) attn_fwd_d64$(PYEXT)
+
+.PHONY: all clean

--- a/kernels/attn/gqa/README.md
+++ b/kernels/attn/gqa/README.md
@@ -1,0 +1,75 @@
+# CDNA3 Flash Attention Forward (GQA, Non-Causal)
+
+MFMA-based flash attention forward kernel for MI300X (gfx942) using HipKittens.
+
+## Architecture
+
+- **MFMA tile**: `mfma_f32_16x16x16` (bf16 inputs, f32 accumulator)
+- **Q tile**: 16 rows per warp, 4 warps = 64 Q rows per block
+- **KV block**: 64 rows per iteration
+- **Head dimensions**: D=128 (`kernel.cpp`) and D=64 (`kernel_d64.cpp`)
+- **Algorithm**: FlashAttention-2 online softmax with base-2 exp
+
+## Tensor Layout
+
+All tensors are `[B, H, N, D]` in bf16:
+- **Q**: `[B, H_Q, N, D]` — query heads
+- **K**: `[B, H_KV, N, D]` — key heads (GQA: H_KV <= H_Q)
+- **V**: `[B, H_KV, N, D]` — value heads
+- **O**: `[B, H_Q, N, D]` — output (bf16)
+- **L**: `[B, H_Q, N, 1]` — log-sum-exp (float32)
+
+## Build
+
+```bash
+source ../../env.src  # Set ROCM_PATH
+make ATTN_B=4 ATTN_H=32 ATTN_H_KV=8 ATTN_N=1024
+```
+
+Build flags:
+- `ATTN_B`: Batch size
+- `ATTN_H`: Number of Q heads
+- `ATTN_H_KV`: Number of KV heads (GQA ratio = H/H_KV)
+- `ATTN_N`: Sequence length
+
+## Test
+
+```bash
+python3 test_python.py --B 4 --H 32 --H_KV 8 --N 1024 --D 128
+python3 test_python.py --B 4 --H 32 --H_KV 8 --N 1024 --D 64
+python3 test_python.py --B 4 --H 32 --H_KV 8 --N 1024 --D 128 --profile
+```
+
+## MMA Type Signatures
+
+- **QK**: `mma_ABt(S, Q, K, S)` — `A[16,D,row] @ B[64,D,row]^T → D[16,64,col]`
+- **PV**: `mma_AB(O, P, V, O)` — `A[16,64,row] @ B[64,D,col] → D[16,D,col]`
+
+## Optimization: Register-Buffer Pipeline
+
+Uses `load_global_to_register_buffer` / `store_register_buffer_to_shared` to overlap global memory loads with MFMA compute:
+- V load overlaps with QK compute + softmax
+- K[kv+1] prefetch overlaps with PV compute
+- AMD scheduling hints (`__builtin_amdgcn_s_setprio`, `__builtin_amdgcn_sched_barrier`) around MMA clusters
+
+## Shared Memory
+
+- D=128: 16KB (single KV tile: 64 x 128 x 2B, K and V alternate via register buffer)
+- D=64: 8KB (single KV tile: 64 x 64 x 2B)
+
+## Register Pressure
+
+**D=128** (`__launch_bounds__(256, 1)` — 1 wave/SIMD):
+- 256 VGPRs + 236 AGPRs, 0 spills, 20 bytes/lane scratch
+- Register buffer: `float4 kv_buf[4]` = 16 VGPRs
+
+**D=64** (`__launch_bounds__(256, 2)` — 2 waves/SIMD):
+- 254 VGPRs, 0 spills, 20 bytes/lane scratch
+- Register buffer: `float4 kv_buf[2]` = 8 VGPRs
+
+## Performance (MI300X, B=4, H=32, H_KV=8, N=1024)
+
+| Variant | Kernel TFLOPS | PyTorch SDPA | Speedup |
+|---------|--------------|--------------|---------|
+| D=128 non-causal | 69.0 | 55.4 | 1.25x |
+| D=64 non-causal | 72.7 | 53.0 | 1.37x |

--- a/kernels/attn/gqa/kernel.cpp
+++ b/kernels/attn/gqa/kernel.cpp
@@ -1,0 +1,269 @@
+/**
+ * @file kernel.cpp
+ * @brief CDNA3 Flash Attention Forward (Non-Causal, D=128) using MFMA 16x16x16
+ *
+ * FlashAttention-2 online softmax with base-2 exp for numerical stability.
+ * Uses mfma_f32_16x16x16 (bf16 inputs, f32 accumulator).
+ *
+ * Tile config:
+ *   Q_ROWS = 16 per warp, KV_BLOCK = 64, NUM_WARPS = 4
+ *   Total Q rows per block = 64
+ *   Shared memory: 16KB (single st_bf<64,128>, K and V alternate)
+ *
+ * Optimization: register-buffer pipeline overlaps global memory loads
+ * with MFMA compute via load_global_to_register_buffer / store_register_buffer_to_shared.
+ */
+
+#include "kittens.cuh"
+#include "pyutils/pyutils.cuh"
+using namespace kittens;
+
+// Compile-time shape parameters (set via -D flags or defaults)
+#ifndef ATTN_B
+#define ATTN_B 4
+#endif
+#ifndef ATTN_H
+#define ATTN_H 32
+#endif
+#ifndef ATTN_H_KV
+#define ATTN_H_KV 8
+#endif
+#ifndef ATTN_N
+#define ATTN_N 1024
+#endif
+
+// Kernel configuration
+constexpr int D          = 128;   // Head dimension
+constexpr int Q_ROWS     = 16;    // Q rows per warp (one MFMA row tile)
+constexpr int KV_BLOCK   = 64;    // KV rows processed per iteration
+constexpr int NUM_WARPS  = 4;     // Warps per block
+constexpr int NUM_THREADS = kittens::WARP_THREADS * NUM_WARPS; // 256
+
+// GQA group size
+constexpr int GROUP_SIZE = ATTN_H / ATTN_H_KV;
+
+// Temperature constant: 1/sqrt(D) * log2(e) for base-2 softmax
+constexpr float TEMPERATURE = 0.0883883476f * 1.44269504089f; // 1/sqrt(128) * log2(e)
+
+// Register buffer: 4 float4s per thread for st_bf<64, 128>
+// (64*128*sizeof(bf16)) / (256*sizeof(float4)) = 16384/4096 = 4
+constexpr int BUF_ELEMS = 4;
+
+// Global layout: [B, H, N, D] — axis=2 is the sequence dimension
+using gl_bf16 = gl<bf16, -1, -1, -1, -1>;
+using gl_fl32 = gl<float, -1, -1, -1, -1>;
+
+using G = kittens::group<NUM_WARPS>;
+
+struct attn_globals {
+    gl_bf16 Q;      // [B, H_Q, N, D]
+    gl_bf16 K;      // [B, H_KV, N, D]
+    gl_bf16 V;      // [B, H_KV, N, D]
+    gl_bf16 O;      // [B, H_Q, N, D]
+    gl_fl32 L;      // [B, H_Q, N, 1] — LSE (log-sum-exp)
+    int N_seq;      // Sequence length
+    hipStream_t stream;
+
+    dim3 grid()  { return dim3(ATTN_H, (N_seq + Q_ROWS * NUM_WARPS - 1) / (Q_ROWS * NUM_WARPS), ATTN_B); }
+    dim3 block() { return dim3(NUM_THREADS); }
+    size_t dynamic_shared_memory() { return 16384; } // 16KB for single st_bf<64,128>
+};
+
+__global__ __launch_bounds__(NUM_THREADS, 1)
+void flash_attention_fwd(const attn_globals g) {
+    extern __shared__ alignment_dummy __shm[];
+    shared_allocator al((int*)&__shm[0]);
+
+    st_bf<KV_BLOCK, D> (&kv_smem) = al.allocate<st_bf<KV_BLOCK, D>>();
+
+    const int warp_id  = kittens::warpid();
+    const int head_idx = blockIdx.x;
+    const int batch_idx = blockIdx.z;
+    const int head_idx_kv = head_idx / GROUP_SIZE;
+    const int q_block_idx = blockIdx.y;
+    const int q_row_start = q_block_idx * (Q_ROWS * NUM_WARPS) + warp_id * Q_ROWS;
+
+    const int N_seq = g.N_seq;
+    const bool warp_active = (q_row_start < N_seq);
+
+    // ========== Persistent registers (live across all iterations) ==========
+    rt_bf<Q_ROWS, D> q_reg;
+    rt_fl<Q_ROWS, D, ducks::rt_layout::col> o_reg;
+    zero(o_reg);
+
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec norm_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec_prev;
+    neg_infty(max_vec);
+    zero(norm_vec);
+
+    // Register buffer for pipelining global→shared loads (16 VGPRs)
+    float4 kv_buf[BUF_ELEMS];
+
+    // ========== Load Q once, pre-scale by temperature ==========
+    if (warp_active) {
+        load<2>(q_reg, g.Q, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+        const bf16 temp_bf16 = __float2bfloat16(TEMPERATURE);
+        const bf16_2 temp_packed = {temp_bf16, temp_bf16};
+        mul(q_reg, q_reg, temp_packed);
+    }
+
+    // ========== Prologue: issue first K load to register buffer ==========
+    const int kv_blocks = (N_seq + KV_BLOCK - 1) / KV_BLOCK;
+    load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+        {batch_idx, head_idx_kv, 0, 0}, kv_smem);
+
+    // ========== Main KV loop (register-buffer pipeline) ==========
+    for (int kv = 0; kv < kv_blocks; kv++) {
+        // P tile must survive from K phase to V phase
+        rt_bf<Q_ROWS, KV_BLOCK> p_reg;
+
+        // ---- K phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_active) {
+            // Load K from shared to registers (scoped for register reuse)
+            rt_bf<KV_BLOCK, D> k_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(k_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // Issue V[kv] global → register buffer (OVERLAPS with QK compute below)
+            // Safe: k_reg loads from shared are complete, kv_buf can be reused
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+
+            // ---------- QK: S[16, 64] = Q[16, 128] @ K[64, 128]^T ----------
+            rt_fl<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> s_reg;
+            zero(s_reg);
+
+            __builtin_amdgcn_s_setprio(1);
+            mma_ABt(s_reg, q_reg, k_reg, s_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+
+            // Handle boundary: mask out positions beyond N_seq
+            const int kv_start = kv * KV_BLOCK;
+            if (kv_start + KV_BLOCK > N_seq) {
+                const int valid_cols = N_seq - kv_start;
+                right_fill(s_reg, s_reg, valid_cols, -__builtin_inff());
+            }
+
+            // ---------- Online softmax (base-2 exp) ----------
+            copy(max_vec_prev, max_vec);
+            row_max(max_vec, s_reg, max_vec_prev);
+
+            typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec scale_vec;
+            sub(scale_vec, max_vec_prev, max_vec);
+            exp2(scale_vec, scale_vec);
+
+            mul_row(o_reg, o_reg, scale_vec);
+            mul(norm_vec, norm_vec, scale_vec);
+
+            sub_row(s_reg, s_reg, max_vec);
+            exp2(s_reg, s_reg);
+            row_sum(norm_vec, s_reg, norm_vec);
+
+            // ---------- Convert S to bf16 row-major for PV multiply ----------
+            rt_bf<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> p_col;
+            copy(p_col, s_reg);
+            swap_layout(p_reg, p_col);
+        } else {
+            // Inactive warps still issue V load (all threads must participate)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+        }
+        // V loads completing in background during QK+softmax above
+
+        // ---- V phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_active) {
+            // Load V from shared to registers (col-major for mma_AB's B operand)
+            rt_bf<KV_BLOCK, D, ducks::rt_layout::col> v_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(v_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // ---------- PV: O[16, 128] += P[16, 64] @ V[64, 128] ----------
+            __builtin_amdgcn_s_setprio(1);
+            mma_AB(o_reg, p_reg, v_reg, o_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+        }
+
+        // Issue K[kv+1] global → register buffer (OVERLAPS with PV compute above)
+        if (kv + 1 < kv_blocks) {
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+                {batch_idx, head_idx_kv, kv + 1, 0}, kv_smem);
+        }
+
+        __syncthreads();
+    }
+
+    if (!warp_active) return;
+
+    // ========== Final normalization: O /= norm_vec ==========
+    div_row(o_reg, o_reg, norm_vec);
+
+    // ========== Convert O to bf16 and store ==========
+    rt_bf<Q_ROWS, D, ducks::rt_layout::col> o_bf_col;
+    copy(o_bf_col, o_reg);
+
+    rt_bf<Q_ROWS, D> o_bf_row;
+    swap_layout(o_bf_row, o_bf_col);
+
+    store<2>(g.O, o_bf_row, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+
+    // ========== Store LSE = max_vec * ln(2) + log(norm_vec) ==========
+    {
+        const int lane = kittens::laneid();
+        constexpr float LN2 = 0.693147180559945f;
+        const int row_in_group = 4 * (lane / 16);
+
+        float m0 = max_vec.data[0][0].x;
+        float m1 = max_vec.data[0][0].y;
+        float m2 = max_vec.data[0][1].x;
+        float m3 = max_vec.data[0][1].y;
+        float n0 = norm_vec.data[0][0].x;
+        float n1 = norm_vec.data[0][0].y;
+        float n2 = norm_vec.data[0][1].x;
+        float n3 = norm_vec.data[0][1].y;
+
+        float lse0 = m0 * LN2 + __logf(n0 + 1e-10f);
+        float lse1 = m1 * LN2 + __logf(n1 + 1e-10f);
+        float lse2 = m2 * LN2 + __logf(n2 + 1e-10f);
+        float lse3 = m3 * LN2 + __logf(n3 + 1e-10f);
+
+        if (lane % 16 == 0) {
+            int base_row = q_row_start + row_in_group;
+            if (base_row + 0 < N_seq) g.L[{batch_idx, head_idx, base_row + 0, 0}] = lse0;
+            if (base_row + 1 < N_seq) g.L[{batch_idx, head_idx, base_row + 1, 0}] = lse1;
+            if (base_row + 2 < N_seq) g.L[{batch_idx, head_idx, base_row + 2, 0}] = lse2;
+            if (base_row + 3 < N_seq) g.L[{batch_idx, head_idx, base_row + 3, 0}] = lse3;
+        }
+    }
+}
+
+void dispatch_attn(attn_globals g) {
+    unsigned long mem_size = g.dynamic_shared_memory();
+    hipFuncSetAttribute((void*)flash_attention_fwd, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    flash_attention_fwd<<<g.grid(), g.block(), mem_size, g.stream>>>(g);
+}
+
+PYBIND11_MODULE(attn_fwd, m) {
+    m.doc() = "CDNA3 Flash Attention Forward (Non-Causal, D=128)";
+    py::bind_function<dispatch_attn>(m, "attention",
+        &attn_globals::Q, &attn_globals::K, &attn_globals::V,
+        &attn_globals::O, &attn_globals::L, &attn_globals::N_seq);
+}

--- a/kernels/attn/gqa/kernel_d64.cpp
+++ b/kernels/attn/gqa/kernel_d64.cpp
@@ -1,0 +1,258 @@
+/**
+ * @file kernel_d64.cpp
+ * @brief CDNA3 Flash Attention Forward (Non-Causal, D=64) using MFMA 16x16x16
+ *
+ * FlashAttention-2 online softmax with base-2 exp for numerical stability.
+ * Uses mfma_f32_16x16x16 (bf16 inputs, f32 accumulator).
+ *
+ * D=64 variant: half the MFMA calls per QK/PV vs D=128.
+ *   Q_ROWS = 16 per warp, KV_BLOCK = 64, NUM_WARPS = 4
+ *   Total Q rows per block = 64
+ *   Shared memory: 8KB (single st_bf<64,64>, K and V alternate)
+ *
+ * Optimization: register-buffer pipeline overlaps global memory loads
+ * with MFMA compute via load_global_to_register_buffer / store_register_buffer_to_shared.
+ */
+
+#include "kittens.cuh"
+#include "pyutils/pyutils.cuh"
+using namespace kittens;
+
+#ifndef ATTN_B
+#define ATTN_B 4
+#endif
+#ifndef ATTN_H
+#define ATTN_H 32
+#endif
+#ifndef ATTN_H_KV
+#define ATTN_H_KV 8
+#endif
+#ifndef ATTN_N
+#define ATTN_N 1024
+#endif
+
+constexpr int D          = 64;
+constexpr int Q_ROWS     = 16;
+constexpr int KV_BLOCK   = 64;
+constexpr int NUM_WARPS  = 4;
+constexpr int NUM_THREADS = kittens::WARP_THREADS * NUM_WARPS;
+
+constexpr int GROUP_SIZE = ATTN_H / ATTN_H_KV;
+
+// Temperature: 1/sqrt(64) * log2(e) = 0.125 * 1.44269504089
+constexpr float TEMPERATURE = 0.125f * 1.44269504089f;
+
+// Register buffer: 2 float4s per thread for st_bf<64, 64>
+// (64*64*sizeof(bf16)) / (256*sizeof(float4)) = 8192/4096 = 2
+constexpr int BUF_ELEMS = 2;
+
+using gl_bf16 = gl<bf16, -1, -1, -1, -1>;
+using gl_fl32 = gl<float, -1, -1, -1, -1>;
+
+using G = kittens::group<NUM_WARPS>;
+
+struct attn_globals {
+    gl_bf16 Q;
+    gl_bf16 K;
+    gl_bf16 V;
+    gl_bf16 O;
+    gl_fl32 L;
+    int N_seq;
+    hipStream_t stream;
+
+    dim3 grid()  { return dim3(ATTN_H, (N_seq + Q_ROWS * NUM_WARPS - 1) / (Q_ROWS * NUM_WARPS), ATTN_B); }
+    dim3 block() { return dim3(NUM_THREADS); }
+    size_t dynamic_shared_memory() { return 8192; } // 8KB for single st_bf<64,64>
+};
+
+__global__ __launch_bounds__(NUM_THREADS, 2)
+void flash_attention_d64_fwd(const attn_globals g) {
+    extern __shared__ alignment_dummy __shm[];
+    shared_allocator al((int*)&__shm[0]);
+
+    st_bf<KV_BLOCK, D> (&kv_smem) = al.allocate<st_bf<KV_BLOCK, D>>();
+
+    const int warp_id  = kittens::warpid();
+    const int head_idx = blockIdx.x;
+    const int batch_idx = blockIdx.z;
+    const int head_idx_kv = head_idx / GROUP_SIZE;
+    const int q_block_idx = blockIdx.y;
+    const int q_row_start = q_block_idx * (Q_ROWS * NUM_WARPS) + warp_id * Q_ROWS;
+
+    const int N_seq = g.N_seq;
+    const bool warp_active = (q_row_start < N_seq);
+
+    // ========== Persistent registers (live across all iterations) ==========
+    rt_bf<Q_ROWS, D> q_reg;
+    rt_fl<Q_ROWS, D, ducks::rt_layout::col> o_reg;
+    zero(o_reg);
+
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec norm_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec_prev;
+    neg_infty(max_vec);
+    zero(norm_vec);
+
+    // Register buffer for pipelining global→shared loads (8 VGPRs)
+    float4 kv_buf[BUF_ELEMS];
+
+    // ========== Load Q once, pre-scale by temperature ==========
+    if (warp_active) {
+        load<2>(q_reg, g.Q, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+        const bf16 temp_bf16 = __float2bfloat16(TEMPERATURE);
+        const bf16_2 temp_packed = {temp_bf16, temp_bf16};
+        mul(q_reg, q_reg, temp_packed);
+    }
+
+    // ========== Prologue: issue first K load to register buffer ==========
+    const int kv_blocks = (N_seq + KV_BLOCK - 1) / KV_BLOCK;
+    load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+        {batch_idx, head_idx_kv, 0, 0}, kv_smem);
+
+    // ========== Main KV loop (register-buffer pipeline) ==========
+    for (int kv = 0; kv < kv_blocks; kv++) {
+        // P tile must survive from K phase to V phase
+        rt_bf<Q_ROWS, KV_BLOCK> p_reg;
+
+        // ---- K phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_active) {
+            // Load K from shared to registers (scoped for register reuse)
+            rt_bf<KV_BLOCK, D> k_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(k_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // Issue V[kv] global → register buffer (OVERLAPS with QK compute below)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+
+            // ---------- QK: S[16, 64] = Q[16, 64] @ K[64, 64]^T ----------
+            rt_fl<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> s_reg;
+            zero(s_reg);
+
+            __builtin_amdgcn_s_setprio(1);
+            mma_ABt(s_reg, q_reg, k_reg, s_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+
+            // Handle boundary: mask out positions beyond N_seq
+            const int kv_start = kv * KV_BLOCK;
+            if (kv_start + KV_BLOCK > N_seq) {
+                const int valid_cols = N_seq - kv_start;
+                right_fill(s_reg, s_reg, valid_cols, -__builtin_inff());
+            }
+
+            // ---------- Online softmax (base-2 exp) ----------
+            copy(max_vec_prev, max_vec);
+            row_max(max_vec, s_reg, max_vec_prev);
+
+            typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec scale_vec;
+            sub(scale_vec, max_vec_prev, max_vec);
+            exp2(scale_vec, scale_vec);
+
+            mul_row(o_reg, o_reg, scale_vec);
+            mul(norm_vec, norm_vec, scale_vec);
+
+            sub_row(s_reg, s_reg, max_vec);
+            exp2(s_reg, s_reg);
+            row_sum(norm_vec, s_reg, norm_vec);
+
+            // ---------- Convert S to bf16 row-major for PV multiply ----------
+            rt_bf<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> p_col;
+            copy(p_col, s_reg);
+            swap_layout(p_reg, p_col);
+        } else {
+            // Inactive warps still issue V load (all threads must participate)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+        }
+
+        // ---- V phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_active) {
+            // Load V from shared to registers (col-major for mma_AB's B operand)
+            rt_bf<KV_BLOCK, D, ducks::rt_layout::col> v_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(v_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // ---------- PV: O[16, 64] += P[16, 64] @ V[64, 64] ----------
+            __builtin_amdgcn_s_setprio(1);
+            mma_AB(o_reg, p_reg, v_reg, o_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+        }
+
+        // Issue K[kv+1] global → register buffer (OVERLAPS with PV compute above)
+        if (kv + 1 < kv_blocks) {
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+                {batch_idx, head_idx_kv, kv + 1, 0}, kv_smem);
+        }
+
+        __syncthreads();
+    }
+
+    if (!warp_active) return;
+
+    div_row(o_reg, o_reg, norm_vec);
+
+    rt_bf<Q_ROWS, D, ducks::rt_layout::col> o_bf_col;
+    copy(o_bf_col, o_reg);
+    rt_bf<Q_ROWS, D> o_bf_row;
+    swap_layout(o_bf_row, o_bf_col);
+    store<2>(g.O, o_bf_row, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+
+    {
+        const int lane = kittens::laneid();
+        const int row_in_group = 4 * (lane / 16);
+        constexpr float LN2 = 0.693147180559945f;
+
+        float m0 = max_vec.data[0][0].x;
+        float m1 = max_vec.data[0][0].y;
+        float m2 = max_vec.data[0][1].x;
+        float m3 = max_vec.data[0][1].y;
+        float n0 = norm_vec.data[0][0].x;
+        float n1 = norm_vec.data[0][0].y;
+        float n2 = norm_vec.data[0][1].x;
+        float n3 = norm_vec.data[0][1].y;
+
+        float lse0 = m0 * LN2 + __logf(n0 + 1e-10f);
+        float lse1 = m1 * LN2 + __logf(n1 + 1e-10f);
+        float lse2 = m2 * LN2 + __logf(n2 + 1e-10f);
+        float lse3 = m3 * LN2 + __logf(n3 + 1e-10f);
+
+        if (lane % 16 == 0) {
+            int base_row = q_row_start + row_in_group;
+            if (base_row + 0 < N_seq) g.L[{batch_idx, head_idx, base_row + 0, 0}] = lse0;
+            if (base_row + 1 < N_seq) g.L[{batch_idx, head_idx, base_row + 1, 0}] = lse1;
+            if (base_row + 2 < N_seq) g.L[{batch_idx, head_idx, base_row + 2, 0}] = lse2;
+            if (base_row + 3 < N_seq) g.L[{batch_idx, head_idx, base_row + 3, 0}] = lse3;
+        }
+    }
+}
+
+void dispatch_attn_d64(attn_globals g) {
+    unsigned long mem_size = g.dynamic_shared_memory();
+    hipFuncSetAttribute((void*)flash_attention_d64_fwd, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    flash_attention_d64_fwd<<<g.grid(), g.block(), mem_size, g.stream>>>(g);
+}
+
+PYBIND11_MODULE(attn_fwd_d64, m) {
+    m.doc() = "CDNA3 Flash Attention Forward (Non-Causal, D=64)";
+    py::bind_function<dispatch_attn_d64>(m, "attention",
+        &attn_globals::Q, &attn_globals::K, &attn_globals::V,
+        &attn_globals::O, &attn_globals::L, &attn_globals::N_seq);
+}

--- a/kernels/attn/gqa/test_python.py
+++ b/kernels/attn/gqa/test_python.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Test harness for CDNA3 Flash Attention Forward (Non-Causal).
+Compares kernel output against PyTorch's scaled_dot_product_attention.
+"""
+
+import torch
+import argparse
+import sys
+import os
+import time
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Test CDNA3 Flash Attention Forward")
+    parser.add_argument("--B", type=int, default=4, help="Batch size")
+    parser.add_argument("--H", type=int, default=32, help="Number of Q heads")
+    parser.add_argument("--H_KV", type=int, default=8, help="Number of KV heads")
+    parser.add_argument("--N", type=int, default=1024, help="Sequence length")
+    parser.add_argument("--D", type=int, default=128, help="Head dimension (64 or 128)")
+    parser.add_argument("--profile", action="store_true", help="Run profiling iterations")
+    parser.add_argument("--num_warmup", type=int, default=5, help="Warmup iterations")
+    parser.add_argument("--num_iters", type=int, default=20, help="Timing iterations")
+    return parser.parse_args()
+
+def reference_attention(Q, K, V, is_causal=False):
+    """PyTorch reference: scaled_dot_product_attention."""
+    # Q: [B, H, N, D], K: [B, H_KV, N, D], V: [B, H_KV, N, D]
+    B, H, N, D = Q.shape
+    H_KV = K.shape[1]
+    group_size = H // H_KV
+
+    # Expand KV heads for GQA
+    K_expanded = K.repeat_interleave(group_size, dim=1)  # [B, H, N, D]
+    V_expanded = V.repeat_interleave(group_size, dim=1)  # [B, H, N, D]
+
+    return torch.nn.functional.scaled_dot_product_attention(
+        Q.float(), K_expanded.float(), V_expanded.float(), is_causal=is_causal
+    ).to(torch.bfloat16)
+
+def test_attention(args):
+    B, H, H_KV, N, D = args.B, args.H, args.H_KV, args.N, args.D
+
+    # Kernel tile alignment: Q_ROWS=16, NUM_WARPS=4 → 64 rows per block
+    # Store uses raw pointers (no OOB protection), so pad output tensors
+    BLOCK_SIZE = 64  # Q_ROWS * NUM_WARPS
+    N_pad = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+
+    print(f"Testing Flash Attention Forward (Non-Causal)")
+    print(f"  B={B}, H={H}, H_KV={H_KV}, N={N}, D={D}" + (f" (padded to {N_pad})" if N_pad != N else ""))
+    print(f"  GQA ratio: {H // H_KV}")
+    print()
+
+    # Import the appropriate kernel module
+    if D == 128:
+        import attn_fwd as kernel_mod
+    elif D == 64:
+        import attn_fwd_d64 as kernel_mod
+    else:
+        raise ValueError(f"Unsupported D={D}. Use 64 or 128.")
+
+    torch.manual_seed(42)
+
+    # Create inputs [B, H, N, D] in bf16 — padded to N_pad with zeros
+    Q = torch.zeros(B, H, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    K = torch.zeros(B, H_KV, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    V = torch.zeros(B, H_KV, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    Q[:, :, :N, :] = torch.randn(B, H, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+    K[:, :, :N, :] = torch.randn(B, H_KV, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+    V[:, :, :N, :] = torch.randn(B, H_KV, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+
+    # Output buffers (padded)
+    O = torch.zeros(B, H, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    L = torch.zeros(B, H, N_pad, 1, dtype=torch.float32, device='cuda')
+
+    # Reference output (use only valid rows)
+    O_ref = reference_attention(Q[:, :, :N, :], K[:, :, :N, :], V[:, :, :N, :], is_causal=False)
+
+    # Run kernel
+    kernel_mod.attention(Q, K, V, O, L, N)
+    torch.cuda.synchronize()
+
+    # Compare only valid rows
+    O_float = O[:, :, :N, :].float()
+    O_ref_float = O_ref.float()
+
+    diff = (O_float - O_ref_float).abs()
+    max_error = diff.max().item()
+    mean_error = diff.mean().item()
+
+    # Cosine similarity (per-sample)
+    cos_sim = torch.nn.functional.cosine_similarity(
+        O_float.reshape(B, -1), O_ref_float.reshape(B, -1), dim=1
+    ).mean().item()
+
+    print(f"=== Correctness ===")
+    print(f"  Max error:  {max_error:.6f}")
+    print(f"  Mean error: {mean_error:.6f}")
+    print(f"  Cosine sim: {cos_sim:.6f}")
+
+    passed = cos_sim > 0.999
+    print(f"  Status:     {'PASS' if passed else 'FAIL'} (threshold: cosine_sim > 0.999)")
+    print()
+
+    # Profiling
+    if args.profile:
+        # Warmup
+        for _ in range(args.num_warmup):
+            kernel_mod.attention(Q, K, V, O, L, N)
+        torch.cuda.synchronize()
+
+        # Timing
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        timings = []
+        for _ in range(args.num_iters):
+            torch.cuda.synchronize()
+            start_event.record()
+            kernel_mod.attention(Q, K, V, O, L, N)
+            end_event.record()
+            torch.cuda.synchronize()
+            timings.append(start_event.elapsed_time(end_event))
+
+        avg_time = sum(timings) / len(timings)
+        # FLOPs: 2 * B * H * N * N * D (QK) + 2 * B * H * N * N * D (PV) = 4 * B * H * N^2 * D
+        flops = 4 * B * H * N * N * D
+        tflops = flops / (avg_time * 1e9)
+
+        print(f"=== Performance ===")
+        print(f"  Avg time:   {avg_time:.4f} ms")
+        print(f"  TFLOPS:     {tflops:.2f}")
+        print()
+
+        # Reference timing
+        timings_ref = []
+        for _ in range(args.num_warmup):
+            _ = reference_attention(Q, K, V)
+        for _ in range(args.num_iters):
+            torch.cuda.synchronize()
+            start_event.record()
+            O_ref = reference_attention(Q, K, V)
+            end_event.record()
+            torch.cuda.synchronize()
+            timings_ref.append(start_event.elapsed_time(end_event))
+
+        avg_time_ref = sum(timings_ref) / len(timings_ref)
+        tflops_ref = flops / (avg_time_ref * 1e9)
+        print(f"  PyTorch ref avg time: {avg_time_ref:.4f} ms")
+        print(f"  PyTorch ref TFLOPS:   {tflops_ref:.2f}")
+        print(f"  Speedup:              {avg_time_ref / avg_time:.2f}x")
+
+    return passed
+
+def run_shape_sweep():
+    """Test multiple shapes for robustness."""
+    shapes = [
+        # (B, H, H_KV, N, D)
+        (1, 8, 8, 128, 128),     # MHA, small
+        (4, 32, 8, 1024, 128),   # GQA-4, medium
+        (2, 16, 2, 2048, 128),   # GQA-8, large
+        (1, 32, 4, 4096, 128),   # GQA-8, very large
+    ]
+
+    # Only test D=64 shapes if the module exists
+    try:
+        import attn_fwd_d64
+        shapes += [
+            (1, 8, 8, 128, 64),
+            (4, 32, 8, 1024, 64),
+        ]
+    except ImportError:
+        print("Note: attn_fwd_d64 not built, skipping D=64 tests")
+
+    all_passed = True
+    for B, H, H_KV, N, D in shapes:
+        test_args = argparse.Namespace(B=B, H=H, H_KV=H_KV, N=N, D=D, profile=False, num_warmup=1, num_iters=1)
+        try:
+            passed = test_attention(test_args)
+            if not passed:
+                all_passed = False
+        except Exception as e:
+            print(f"  FAIL: {e}")
+            all_passed = False
+
+    return all_passed
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    if args.B == 0:
+        # Special mode: run shape sweep
+        all_passed = run_shape_sweep()
+        sys.exit(0 if all_passed else 1)
+    else:
+        passed = test_attention(args)
+        sys.exit(0 if passed else 1)

--- a/kernels/attn/gqa_causal/Makefile
+++ b/kernels/attn/gqa_causal/Makefile
@@ -1,0 +1,53 @@
+# CDNA3 Flash Attention Forward (Causal) Makefile
+GPU_TARGET=CDNA3
+
+THUNDERKITTENS_ROOT ?= $(abspath ../../../)
+
+ATTN_B     ?= 4
+ATTN_H     ?= 32
+ATTN_H_KV  ?= 8
+ATTN_N     ?= 1024
+
+ROCM_INSTALL_DIR := $(ROCM_PATH)
+HIP_INCLUDE_DIR  := $(ROCM_INSTALL_DIR)/include/hip
+ROCM_INCLUDE_DIR := $(ROCM_INSTALL_DIR)/include
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+ifeq ($(GPU_TARGET),CDNA3)
+HIPFLAGS += -DKITTENS_CDNA3 --offload-arch=gfx942
+endif
+
+CXX_STD   := c++20
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -I${THUNDERKITTENS_ROOT}/include -I$(ROCM_INCLUDE_DIR) -I$(HIP_INCLUDE_DIR)
+ILDFLAGS  :=
+ILDLIBS   :=
+
+CXXFLAGS := -w
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+ICXXFLAGS += $(shell python3 -m pybind11 --includes) $(shell python3-config --ldflags) -shared -fPIC
+ICXXFLAGS += -Rpass-analysis=kernel-resource-usage
+
+SHAPE_FLAGS = -DATTN_B=$(ATTN_B) -DATTN_H=$(ATTN_H) -DATTN_H_KV=$(ATTN_H_KV) -DATTN_N=$(ATTN_N)
+
+PYEXT := $(shell python3-config --extension-suffix)
+
+all: attn_causal_fwd attn_causal_fwd_d64
+
+attn_causal_fwd: kernel.cpp
+	$(HIPCXX) kernel.cpp $(HIPFLAGS) $(SHAPE_FLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) \
+	    -o attn_causal_fwd$(PYEXT) 2>&1
+
+attn_causal_fwd_d64: kernel_d64.cpp
+	$(HIPCXX) kernel_d64.cpp $(HIPFLAGS) $(SHAPE_FLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) \
+	    -o attn_causal_fwd_d64$(PYEXT) 2>&1
+
+clean:
+	rm -f attn_causal_fwd$(PYEXT) attn_causal_fwd_d64$(PYEXT)
+
+.PHONY: all clean

--- a/kernels/attn/gqa_causal/kernel.cpp
+++ b/kernels/attn/gqa_causal/kernel.cpp
@@ -1,0 +1,277 @@
+/**
+ * @file kernel.cpp
+ * @brief CDNA3 Flash Attention Forward (Causal, D=128) using MFMA 16x16x16
+ *
+ * FlashAttention-2 with causal masking and online softmax (base-2 exp).
+ * Uses mfma_f32_16x16x16 (bf16 inputs, f32 accumulator).
+ *
+ * Causal masking:
+ *   - Early termination when KV block is entirely past Q positions
+ *   - Per-tile triangular masking for partial overlap blocks
+ *   - Positions where kv_col > q_row are masked to -inf before softmax
+ *
+ * Optimization: register-buffer pipeline overlaps global memory loads
+ * with MFMA compute via load_global_to_register_buffer / store_register_buffer_to_shared.
+ */
+
+#include "kittens.cuh"
+#include "pyutils/pyutils.cuh"
+using namespace kittens;
+
+#ifndef ATTN_B
+#define ATTN_B 4
+#endif
+#ifndef ATTN_H
+#define ATTN_H 32
+#endif
+#ifndef ATTN_H_KV
+#define ATTN_H_KV 8
+#endif
+#ifndef ATTN_N
+#define ATTN_N 1024
+#endif
+
+constexpr int D          = 128;
+constexpr int Q_ROWS     = 16;
+constexpr int KV_BLOCK   = 64;
+constexpr int NUM_WARPS  = 4;
+constexpr int NUM_THREADS = kittens::WARP_THREADS * NUM_WARPS;
+
+constexpr int GROUP_SIZE = ATTN_H / ATTN_H_KV;
+constexpr float TEMPERATURE = 0.0883883476f * 1.44269504089f; // 1/sqrt(128) * log2(e)
+
+// Register buffer: 4 float4s per thread for st_bf<64, 128>
+constexpr int BUF_ELEMS = 4;
+
+using gl_bf16 = gl<bf16, -1, -1, -1, -1>;
+using gl_fl32 = gl<float, -1, -1, -1, -1>;
+
+using G = kittens::group<NUM_WARPS>;
+
+struct attn_globals {
+    gl_bf16 Q;
+    gl_bf16 K;
+    gl_bf16 V;
+    gl_bf16 O;
+    gl_fl32 L;
+    int N_seq;
+    hipStream_t stream;
+
+    dim3 grid()  { return dim3(ATTN_H, (N_seq + Q_ROWS * NUM_WARPS - 1) / (Q_ROWS * NUM_WARPS), ATTN_B); }
+    dim3 block() { return dim3(NUM_THREADS); }
+    size_t dynamic_shared_memory() { return 16384; } // 16KB for single st_bf<64,128>
+};
+
+__global__ __launch_bounds__(NUM_THREADS, 1)
+void flash_attention_causal_fwd(const attn_globals g) {
+    extern __shared__ alignment_dummy __shm[];
+    shared_allocator al((int*)&__shm[0]);
+
+    st_bf<KV_BLOCK, D> (&kv_smem) = al.allocate<st_bf<KV_BLOCK, D>>();
+
+    const int warp_id  = kittens::warpid();
+    const int head_idx = blockIdx.x;
+    const int batch_idx = blockIdx.z;
+    const int head_idx_kv = head_idx / GROUP_SIZE;
+    const int q_block_idx = blockIdx.y;
+    const int q_row_start = q_block_idx * (Q_ROWS * NUM_WARPS) + warp_id * Q_ROWS;
+
+    const int N_seq = g.N_seq;
+    const bool warp_active = (q_row_start < N_seq);
+
+    // The last Q row this warp is responsible for (for causal boundary)
+    const int q_row_end = q_row_start + Q_ROWS - 1;
+
+    // ========== Persistent registers (live across all iterations) ==========
+    rt_bf<Q_ROWS, D> q_reg;
+    rt_fl<Q_ROWS, D, ducks::rt_layout::col> o_reg;
+    zero(o_reg);
+
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec norm_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec_prev;
+    neg_infty(max_vec);
+    zero(norm_vec);
+
+    // Register buffer for pipelining global→shared loads (16 VGPRs)
+    float4 kv_buf[BUF_ELEMS];
+
+    // ========== Load Q once, pre-scale by temperature ==========
+    if (warp_active) {
+        load<2>(q_reg, g.Q, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+        const bf16 temp_bf16 = __float2bfloat16(TEMPERATURE);
+        const bf16_2 temp_packed = {temp_bf16, temp_bf16};
+        mul(q_reg, q_reg, temp_packed);
+    }
+
+    // For causal: use the maximum possible KV blocks across all warps in the block
+    // All warps must iterate the same number of times for register-buffer loads
+    const int block_q_row_end = (q_block_idx + 1) * (Q_ROWS * NUM_WARPS) - 1;
+    const int max_kv_block = (min(block_q_row_end, N_seq - 1) / KV_BLOCK) + 1;
+    const int kv_blocks = min(max_kv_block, (N_seq + KV_BLOCK - 1) / KV_BLOCK);
+
+    // ========== Prologue: issue first K load to register buffer ==========
+    load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+        {batch_idx, head_idx_kv, 0, 0}, kv_smem);
+
+    // ========== Main KV loop (register-buffer pipeline) ==========
+    for (int kv = 0; kv < kv_blocks; kv++) {
+        const int kv_start = kv * KV_BLOCK;
+
+        // P tile must survive from K phase to V phase
+        rt_bf<Q_ROWS, KV_BLOCK> p_reg;
+
+        // Only compute if this warp is active AND KV block is relevant for causal
+        const bool warp_computes = warp_active && (kv_start <= q_row_end);
+
+        // ---- K phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_computes) {
+            // Load K from shared to registers (scoped for register reuse)
+            rt_bf<KV_BLOCK, D> k_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(k_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // Issue V[kv] global → register buffer (OVERLAPS with QK compute below)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+
+            // ---------- QK: S[16, 64] = Q[16, 128] @ K[64, 128]^T ----------
+            rt_fl<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> s_reg;
+            zero(s_reg);
+
+            __builtin_amdgcn_s_setprio(1);
+            mma_ABt(s_reg, q_reg, k_reg, s_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+
+            // Apply causal mask
+            const bool needs_causal_mask = (kv_start + KV_BLOCK - 1 > q_row_start);
+            if (needs_causal_mask) {
+                const int mask_offset = kv_start - q_row_start;
+                tril(s_reg, s_reg, mask_offset, -__builtin_inff());
+            }
+
+            // Handle boundary: mask out positions beyond N_seq
+            if (kv_start + KV_BLOCK > N_seq) {
+                const int valid_cols = N_seq - kv_start;
+                right_fill(s_reg, s_reg, valid_cols, -__builtin_inff());
+            }
+
+            // ---------- Online softmax (base-2 exp) ----------
+            copy(max_vec_prev, max_vec);
+            row_max(max_vec, s_reg, max_vec_prev);
+
+            typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec scale_vec;
+            sub(scale_vec, max_vec_prev, max_vec);
+            exp2(scale_vec, scale_vec);
+
+            mul_row(o_reg, o_reg, scale_vec);
+            mul(norm_vec, norm_vec, scale_vec);
+
+            sub_row(s_reg, s_reg, max_vec);
+            exp2(s_reg, s_reg);
+            row_sum(norm_vec, s_reg, norm_vec);
+
+            // ---------- Convert S to bf16 row-major for PV multiply ----------
+            rt_bf<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> p_col;
+            copy(p_col, s_reg);
+            swap_layout(p_reg, p_col);
+        } else {
+            // Inactive/skipped warps still issue V load (all threads must participate)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+        }
+
+        // ---- V phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_computes) {
+            // Load V from shared to registers (col-major for mma_AB's B operand)
+            rt_bf<KV_BLOCK, D, ducks::rt_layout::col> v_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(v_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // ---------- PV: O[16, 128] += P[16, 64] @ V[64, 128] ----------
+            __builtin_amdgcn_s_setprio(1);
+            mma_AB(o_reg, p_reg, v_reg, o_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+        }
+
+        // Issue K[kv+1] global → register buffer (OVERLAPS with PV compute above)
+        if (kv + 1 < kv_blocks) {
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+                {batch_idx, head_idx_kv, kv + 1, 0}, kv_smem);
+        }
+
+        __syncthreads();
+    }
+
+    if (!warp_active) return;
+
+    // Normalize
+    div_row(o_reg, o_reg, norm_vec);
+
+    // Store O
+    rt_bf<Q_ROWS, D, ducks::rt_layout::col> o_bf_col;
+    copy(o_bf_col, o_reg);
+    rt_bf<Q_ROWS, D> o_bf_row;
+    swap_layout(o_bf_row, o_bf_col);
+    store<2>(g.O, o_bf_row, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+
+    // Store LSE
+    {
+        const int lane = kittens::laneid();
+        const int row_in_group = 4 * (lane / 16);
+        constexpr float LN2 = 0.693147180559945f;
+
+        float m0 = max_vec.data[0][0].x;
+        float m1 = max_vec.data[0][0].y;
+        float m2 = max_vec.data[0][1].x;
+        float m3 = max_vec.data[0][1].y;
+        float n0 = norm_vec.data[0][0].x;
+        float n1 = norm_vec.data[0][0].y;
+        float n2 = norm_vec.data[0][1].x;
+        float n3 = norm_vec.data[0][1].y;
+
+        float lse0 = m0 * LN2 + __logf(n0 + 1e-10f);
+        float lse1 = m1 * LN2 + __logf(n1 + 1e-10f);
+        float lse2 = m2 * LN2 + __logf(n2 + 1e-10f);
+        float lse3 = m3 * LN2 + __logf(n3 + 1e-10f);
+
+        if (lane % 16 == 0) {
+            int base_row = q_row_start + row_in_group;
+            if (base_row + 0 < N_seq) g.L[{batch_idx, head_idx, base_row + 0, 0}] = lse0;
+            if (base_row + 1 < N_seq) g.L[{batch_idx, head_idx, base_row + 1, 0}] = lse1;
+            if (base_row + 2 < N_seq) g.L[{batch_idx, head_idx, base_row + 2, 0}] = lse2;
+            if (base_row + 3 < N_seq) g.L[{batch_idx, head_idx, base_row + 3, 0}] = lse3;
+        }
+    }
+}
+
+void dispatch_attn_causal(attn_globals g) {
+    unsigned long mem_size = g.dynamic_shared_memory();
+    hipFuncSetAttribute((void*)flash_attention_causal_fwd, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    flash_attention_causal_fwd<<<g.grid(), g.block(), mem_size, g.stream>>>(g);
+}
+
+PYBIND11_MODULE(attn_causal_fwd, m) {
+    m.doc() = "CDNA3 Flash Attention Forward (Causal, D=128)";
+    py::bind_function<dispatch_attn_causal>(m, "attention",
+        &attn_globals::Q, &attn_globals::K, &attn_globals::V,
+        &attn_globals::O, &attn_globals::L, &attn_globals::N_seq);
+}

--- a/kernels/attn/gqa_causal/kernel_d64.cpp
+++ b/kernels/attn/gqa_causal/kernel_d64.cpp
@@ -1,0 +1,268 @@
+/**
+ * @file kernel_d64.cpp
+ * @brief CDNA3 Flash Attention Forward (Causal, D=64) using MFMA 16x16x16
+ *
+ * FlashAttention-2 with causal masking and online softmax (base-2 exp).
+ * D=64 variant: half the MFMA calls, lower register pressure.
+ *
+ * Optimization: register-buffer pipeline overlaps global memory loads
+ * with MFMA compute via load_global_to_register_buffer / store_register_buffer_to_shared.
+ */
+
+#include "kittens.cuh"
+#include "pyutils/pyutils.cuh"
+using namespace kittens;
+
+#ifndef ATTN_B
+#define ATTN_B 4
+#endif
+#ifndef ATTN_H
+#define ATTN_H 32
+#endif
+#ifndef ATTN_H_KV
+#define ATTN_H_KV 8
+#endif
+#ifndef ATTN_N
+#define ATTN_N 1024
+#endif
+
+constexpr int D          = 64;
+constexpr int Q_ROWS     = 16;
+constexpr int KV_BLOCK   = 64;
+constexpr int NUM_WARPS  = 4;
+constexpr int NUM_THREADS = kittens::WARP_THREADS * NUM_WARPS;
+
+constexpr int GROUP_SIZE = ATTN_H / ATTN_H_KV;
+constexpr float TEMPERATURE = 0.125f * 1.44269504089f; // 1/sqrt(64) * log2(e)
+
+// Register buffer: 2 float4s per thread for st_bf<64, 64>
+constexpr int BUF_ELEMS = 2;
+
+using gl_bf16 = gl<bf16, -1, -1, -1, -1>;
+using gl_fl32 = gl<float, -1, -1, -1, -1>;
+
+using G = kittens::group<NUM_WARPS>;
+
+struct attn_globals {
+    gl_bf16 Q;
+    gl_bf16 K;
+    gl_bf16 V;
+    gl_bf16 O;
+    gl_fl32 L;
+    int N_seq;
+    hipStream_t stream;
+
+    dim3 grid()  { return dim3(ATTN_H, (N_seq + Q_ROWS * NUM_WARPS - 1) / (Q_ROWS * NUM_WARPS), ATTN_B); }
+    dim3 block() { return dim3(NUM_THREADS); }
+    size_t dynamic_shared_memory() { return 8192; } // 8KB for single st_bf<64,64>
+};
+
+__global__ __launch_bounds__(NUM_THREADS, 2)
+void flash_attention_causal_d64_fwd(const attn_globals g) {
+    extern __shared__ alignment_dummy __shm[];
+    shared_allocator al((int*)&__shm[0]);
+
+    st_bf<KV_BLOCK, D> (&kv_smem) = al.allocate<st_bf<KV_BLOCK, D>>();
+
+    const int warp_id  = kittens::warpid();
+    const int head_idx = blockIdx.x;
+    const int batch_idx = blockIdx.z;
+    const int head_idx_kv = head_idx / GROUP_SIZE;
+    const int q_block_idx = blockIdx.y;
+    const int q_row_start = q_block_idx * (Q_ROWS * NUM_WARPS) + warp_id * Q_ROWS;
+
+    const int N_seq = g.N_seq;
+    const bool warp_active = (q_row_start < N_seq);
+
+    const int q_row_end = q_row_start + Q_ROWS - 1;
+
+    // ========== Persistent registers (live across all iterations) ==========
+    rt_bf<Q_ROWS, D> q_reg;
+    rt_fl<Q_ROWS, D, ducks::rt_layout::col> o_reg;
+    zero(o_reg);
+
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec norm_vec;
+    typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec max_vec_prev;
+    neg_infty(max_vec);
+    zero(norm_vec);
+
+    // Register buffer for pipelining global→shared loads (8 VGPRs)
+    float4 kv_buf[BUF_ELEMS];
+
+    // ========== Load Q once, pre-scale by temperature ==========
+    if (warp_active) {
+        load<2>(q_reg, g.Q, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+        const bf16 temp_bf16 = __float2bfloat16(TEMPERATURE);
+        const bf16_2 temp_packed = {temp_bf16, temp_bf16};
+        mul(q_reg, q_reg, temp_packed);
+    }
+
+    // For causal: use the maximum possible KV blocks across all warps in the block
+    // All warps must iterate the same number of times for register-buffer loads
+    const int block_q_row_end = (q_block_idx + 1) * (Q_ROWS * NUM_WARPS) - 1;
+    const int max_kv_block = (min(block_q_row_end, N_seq - 1) / KV_BLOCK) + 1;
+    const int kv_blocks = min(max_kv_block, (N_seq + KV_BLOCK - 1) / KV_BLOCK);
+
+    // ========== Prologue: issue first K load to register buffer ==========
+    load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+        {batch_idx, head_idx_kv, 0, 0}, kv_smem);
+
+    // ========== Main KV loop (register-buffer pipeline) ==========
+    for (int kv = 0; kv < kv_blocks; kv++) {
+        const int kv_start = kv * KV_BLOCK;
+
+        // P tile must survive from K phase to V phase
+        rt_bf<Q_ROWS, KV_BLOCK> p_reg;
+
+        // Only compute if this warp is active AND KV block is relevant for causal
+        const bool warp_computes = warp_active && (kv_start <= q_row_end);
+
+        // ---- K phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_computes) {
+            // Load K from shared to registers (scoped for register reuse)
+            rt_bf<KV_BLOCK, D> k_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(k_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // Issue V[kv] global → register buffer (OVERLAPS with QK compute below)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+
+            // ---------- QK: S[16, 64] = Q[16, 64] @ K[64, 64]^T ----------
+            rt_fl<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> s_reg;
+            zero(s_reg);
+
+            __builtin_amdgcn_s_setprio(1);
+            mma_ABt(s_reg, q_reg, k_reg, s_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+
+            // Apply causal mask
+            const bool needs_causal_mask = (kv_start + KV_BLOCK - 1 > q_row_start);
+            if (needs_causal_mask) {
+                const int mask_offset = kv_start - q_row_start;
+                tril(s_reg, s_reg, mask_offset, -__builtin_inff());
+            }
+
+            // Handle boundary: mask out positions beyond N_seq
+            if (kv_start + KV_BLOCK > N_seq) {
+                const int valid_cols = N_seq - kv_start;
+                right_fill(s_reg, s_reg, valid_cols, -__builtin_inff());
+            }
+
+            // ---------- Online softmax (base-2 exp) ----------
+            copy(max_vec_prev, max_vec);
+            row_max(max_vec, s_reg, max_vec_prev);
+
+            typename rt_fl<Q_ROWS, D, ducks::rt_layout::col>::col_vec scale_vec;
+            sub(scale_vec, max_vec_prev, max_vec);
+            exp2(scale_vec, scale_vec);
+
+            mul_row(o_reg, o_reg, scale_vec);
+            mul(norm_vec, norm_vec, scale_vec);
+
+            sub_row(s_reg, s_reg, max_vec);
+            exp2(s_reg, s_reg);
+            row_sum(norm_vec, s_reg, norm_vec);
+
+            // ---------- Convert S to bf16 row-major for PV multiply ----------
+            rt_bf<Q_ROWS, KV_BLOCK, ducks::rt_layout::col> p_col;
+            copy(p_col, s_reg);
+            swap_layout(p_reg, p_col);
+        } else {
+            // Inactive/skipped warps still issue V load (all threads must participate)
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.V,
+                {batch_idx, head_idx_kv, kv, 0}, kv_smem);
+        }
+
+        // ---- V phase: register buffer → shared → registers ----
+        store_register_buffer_to_shared<NUM_THREADS>(kv_smem, kv_buf);
+        __syncthreads();
+
+        if (warp_computes) {
+            // Load V from shared to registers (col-major for mma_AB's B operand)
+            rt_bf<KV_BLOCK, D, ducks::rt_layout::col> v_reg;
+            #pragma unroll
+            for (int sub = 0; sub < KV_BLOCK / Q_ROWS; sub++) {
+                load(
+                    subtile_inplace<Q_ROWS>(v_reg, sub),
+                    subtile_inplace<Q_ROWS, D>(kv_smem, {sub, 0})
+                );
+            }
+
+            // ---------- PV: O[16, 64] += P[16, 64] @ V[64, 64] ----------
+            __builtin_amdgcn_s_setprio(1);
+            mma_AB(o_reg, p_reg, v_reg, o_reg);
+            __builtin_amdgcn_s_setprio(0);
+            __builtin_amdgcn_sched_barrier(0);
+        }
+
+        // Issue K[kv+1] global → register buffer (OVERLAPS with PV compute above)
+        if (kv + 1 < kv_blocks) {
+            load_global_to_register_buffer<2, false, NUM_THREADS>(kv_buf, BUF_ELEMS, g.K,
+                {batch_idx, head_idx_kv, kv + 1, 0}, kv_smem);
+        }
+
+        __syncthreads();
+    }
+
+    if (!warp_active) return;
+
+    div_row(o_reg, o_reg, norm_vec);
+
+    rt_bf<Q_ROWS, D, ducks::rt_layout::col> o_bf_col;
+    copy(o_bf_col, o_reg);
+    rt_bf<Q_ROWS, D> o_bf_row;
+    swap_layout(o_bf_row, o_bf_col);
+    store<2>(g.O, o_bf_row, {batch_idx, head_idx, q_row_start / Q_ROWS, 0});
+
+    {
+        const int lane = kittens::laneid();
+        const int row_in_group = 4 * (lane / 16);
+        constexpr float LN2 = 0.693147180559945f;
+
+        float m0 = max_vec.data[0][0].x;
+        float m1 = max_vec.data[0][0].y;
+        float m2 = max_vec.data[0][1].x;
+        float m3 = max_vec.data[0][1].y;
+        float n0 = norm_vec.data[0][0].x;
+        float n1 = norm_vec.data[0][0].y;
+        float n2 = norm_vec.data[0][1].x;
+        float n3 = norm_vec.data[0][1].y;
+
+        float lse0 = m0 * LN2 + __logf(n0 + 1e-10f);
+        float lse1 = m1 * LN2 + __logf(n1 + 1e-10f);
+        float lse2 = m2 * LN2 + __logf(n2 + 1e-10f);
+        float lse3 = m3 * LN2 + __logf(n3 + 1e-10f);
+
+        if (lane % 16 == 0) {
+            int base_row = q_row_start + row_in_group;
+            if (base_row + 0 < N_seq) g.L[{batch_idx, head_idx, base_row + 0, 0}] = lse0;
+            if (base_row + 1 < N_seq) g.L[{batch_idx, head_idx, base_row + 1, 0}] = lse1;
+            if (base_row + 2 < N_seq) g.L[{batch_idx, head_idx, base_row + 2, 0}] = lse2;
+            if (base_row + 3 < N_seq) g.L[{batch_idx, head_idx, base_row + 3, 0}] = lse3;
+        }
+    }
+}
+
+void dispatch_attn_causal_d64(attn_globals g) {
+    unsigned long mem_size = g.dynamic_shared_memory();
+    hipFuncSetAttribute((void*)flash_attention_causal_d64_fwd, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    flash_attention_causal_d64_fwd<<<g.grid(), g.block(), mem_size, g.stream>>>(g);
+}
+
+PYBIND11_MODULE(attn_causal_fwd_d64, m) {
+    m.doc() = "CDNA3 Flash Attention Forward (Causal, D=64)";
+    py::bind_function<dispatch_attn_causal_d64>(m, "attention",
+        &attn_globals::Q, &attn_globals::K, &attn_globals::V,
+        &attn_globals::O, &attn_globals::L, &attn_globals::N_seq);
+}

--- a/kernels/attn/gqa_causal/test_python.py
+++ b/kernels/attn/gqa_causal/test_python.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Test harness for CDNA3 Flash Attention Forward (Causal).
+Compares kernel output against PyTorch's scaled_dot_product_attention with is_causal=True.
+"""
+
+import torch
+import argparse
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Test CDNA3 Flash Attention Forward (Causal)")
+    parser.add_argument("--B", type=int, default=4, help="Batch size")
+    parser.add_argument("--H", type=int, default=32, help="Number of Q heads")
+    parser.add_argument("--H_KV", type=int, default=8, help="Number of KV heads")
+    parser.add_argument("--N", type=int, default=1024, help="Sequence length")
+    parser.add_argument("--D", type=int, default=128, help="Head dimension (64 or 128)")
+    parser.add_argument("--profile", action="store_true", help="Run profiling iterations")
+    parser.add_argument("--num_warmup", type=int, default=5, help="Warmup iterations")
+    parser.add_argument("--num_iters", type=int, default=20, help="Timing iterations")
+    return parser.parse_args()
+
+def reference_attention_causal(Q, K, V):
+    """PyTorch reference: causal scaled_dot_product_attention."""
+    B, H, N, D = Q.shape
+    H_KV = K.shape[1]
+    group_size = H // H_KV
+
+    K_expanded = K.repeat_interleave(group_size, dim=1)
+    V_expanded = V.repeat_interleave(group_size, dim=1)
+
+    return torch.nn.functional.scaled_dot_product_attention(
+        Q.float(), K_expanded.float(), V_expanded.float(), is_causal=True
+    ).to(torch.bfloat16)
+
+def test_attention(args):
+    B, H, H_KV, N, D = args.B, args.H, args.H_KV, args.N, args.D
+
+    # Kernel tile alignment: Q_ROWS=16, NUM_WARPS=4 → 64 rows per block
+    # Store uses raw pointers (no OOB protection), so pad output tensors
+    BLOCK_SIZE = 64  # Q_ROWS * NUM_WARPS
+    N_pad = ((N + BLOCK_SIZE - 1) // BLOCK_SIZE) * BLOCK_SIZE
+
+    print(f"Testing Flash Attention Forward (Causal)")
+    print(f"  B={B}, H={H}, H_KV={H_KV}, N={N}, D={D}" + (f" (padded to {N_pad})" if N_pad != N else ""))
+    print(f"  GQA ratio: {H // H_KV}")
+    print()
+
+    if D == 128:
+        import attn_causal_fwd as kernel_mod
+    elif D == 64:
+        import attn_causal_fwd_d64 as kernel_mod
+    else:
+        raise ValueError(f"Unsupported D={D}. Use 64 or 128.")
+
+    torch.manual_seed(42)
+
+    # Create inputs padded to N_pad with zeros
+    Q = torch.zeros(B, H, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    K = torch.zeros(B, H_KV, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    V = torch.zeros(B, H_KV, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    Q[:, :, :N, :] = torch.randn(B, H, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+    K[:, :, :N, :] = torch.randn(B, H_KV, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+    V[:, :, :N, :] = torch.randn(B, H_KV, N, D, dtype=torch.bfloat16, device='cuda') / (D ** 0.25)
+
+    # Output buffers (padded)
+    O = torch.zeros(B, H, N_pad, D, dtype=torch.bfloat16, device='cuda')
+    L = torch.zeros(B, H, N_pad, 1, dtype=torch.float32, device='cuda')
+
+    # Reference output (use only valid rows)
+    O_ref = reference_attention_causal(Q[:, :, :N, :], K[:, :, :N, :], V[:, :, :N, :])
+
+    kernel_mod.attention(Q, K, V, O, L, N)
+    torch.cuda.synchronize()
+
+    # Compare only valid rows
+    O_float = O[:, :, :N, :].float()
+    O_ref_float = O_ref.float()
+
+    diff = (O_float - O_ref_float).abs()
+    max_error = diff.max().item()
+    mean_error = diff.mean().item()
+
+    cos_sim = torch.nn.functional.cosine_similarity(
+        O_float.reshape(B, -1), O_ref_float.reshape(B, -1), dim=1
+    ).mean().item()
+
+    print(f"=== Correctness ===")
+    print(f"  Max error:  {max_error:.6f}")
+    print(f"  Mean error: {mean_error:.6f}")
+    print(f"  Cosine sim: {cos_sim:.6f}")
+
+    passed = cos_sim > 0.999
+    print(f"  Status:     {'PASS' if passed else 'FAIL'} (threshold: cosine_sim > 0.999)")
+    print()
+
+    if args.profile:
+        for _ in range(args.num_warmup):
+            kernel_mod.attention(Q, K, V, O, L, N)
+        torch.cuda.synchronize()
+
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+
+        timings = []
+        for _ in range(args.num_iters):
+            torch.cuda.synchronize()
+            start_event.record()
+            kernel_mod.attention(Q, K, V, O, L, N)
+            end_event.record()
+            torch.cuda.synchronize()
+            timings.append(start_event.elapsed_time(end_event))
+
+        avg_time = sum(timings) / len(timings)
+        # Causal: ~half the FLOPs due to triangular masking
+        flops = 2 * B * H * N * N * D  # approximate (half of non-causal)
+        tflops = flops / (avg_time * 1e9)
+
+        print(f"=== Performance ===")
+        print(f"  Avg time:   {avg_time:.4f} ms")
+        print(f"  TFLOPS:     {tflops:.2f} (approximate, causal halves effective work)")
+
+    return passed
+
+if __name__ == "__main__":
+    args = parse_args()
+    passed = test_attention(args)
+    sys.exit(0 if passed else 1)


### PR DESCRIPTION
## Summary
- 4 flash attention forward kernels for MI300X (gfx942): non-causal + causal, D=128 + D=64
- FlashAttention-2 online softmax with base-2 exp, GQA support via head index mapping
- register-buffer pipeline (load_global_to_register_buffer / store_register_buffer_to_shared) overlaps global memory loads with MFMA compute
- launch_bounds(256,1) for D=128 eliminates all VGPR spills by using AGPRs, scratch dropped from 876 to 20 bytes/lane
- scheduling hints (__builtin_amdgcn_s_setprio, sched_barrier) around MMA clusters

## Performance (MI300X, B=4 H=32 H_KV=8 N=1024)
- D=128 non-causal: 69.0 TFLOPS (1.25x PyTorch SDPA)
- D=64 non-causal: 72.7 TFLOPS (1.37x PyTorch SDPA)
- D=128 causal: 54.8 TFLOPS
- D=64 causal: 56.5 TFLOPS

## Test plan
- [x] correctness vs torch.nn.functional.scaled_dot_product_attention (cosine_sim > 0.999)
- [x] tested across N=64, 100, 128, 512, 1024, 2048, 4096
- [x] both causal and non-causal verified
- [x] zero VGPR spills confirmed via -Rpass-analysis=kernel-resource-usage

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)