### PR TITLE
Fix race condition in 8 wave fp8 gemm kernel

### DIFF
--- a/kernels/gemm/fp8fp32/FP8_8wave/8_wave.cu
+++ b/kernels/gemm/fp8fp32/FP8_8wave/8_wave.cu
@@ -8,7 +8,7 @@ using namespace kittens;
 #include "../profile_utils.cpp"
 #include "./utils.cpp"
 
-#define SIZE 16384
+#define SIZE 8192
 
 constexpr int NUM_WARPS = 8;
 


### PR DESCRIPTION
The improved performance from https://github.com/HazyResearch/HipKittens/pull/32 showed us there was a race condition in the 8 wave fp8 gemm kernel (thanks @salykova!). In the epilogue, we had moved the second `b0` shared to register load earlier in the pipeline, but we failed to add an additional `s_waitcnt vmcnt`. We also had suboptimal ordering of global to shared loads - they were not in the same order as shared to register loads. This PR moves to optimal global to shared load ordering and adds the necessary `waitcnt`s in the epilogue.

I added comments showing which vmcnts we need where, but I combined two of them into the previous waitcnt because I think that's slightly more performant after testing.