### PR TITLE
Add standalone softmax kernel

### DIFF
--- a/kernels/softmax/Makefile
+++ b/kernels/softmax/Makefile
@@ -1,0 +1,56 @@
+# Compiler
+GPU_TARGET=CDNA4
+
+TARGET=tk_kernel
+SRC=kernel.cpp
+
+# HIP variables
+ROCM_INSTALL_DIR := $(ROCM_PATH)
+HIP_INCLUDE_DIR  := $(ROCM_INSTALL_DIR)/include/hip
+
+HIPCXX ?= $(ROCM_INSTALL_DIR)/bin/hipcc
+
+# Compiler flags based on GPU target
+ifeq ($(GPU_TARGET),CDNA2)
+HIPFLAGS+= -DKITTENS_CDNA2 --offload-arch=gfx90a
+else ifeq ($(GPU_TARGET),CDNA3)
+HIPFLAGS+= -DKITTENS_CDNA3 --offload-arch=gfx942
+else ifeq ($(GPU_TARGET),CDNA4)
+HIPFLAGS+= -DKITTENS_CDNA4 --offload-arch=gfx950 -DHIP_ENABLE_WARP_SYNC_BUILTINS -ffast-math -I/opt/rocm/include/rocrand
+
+endif
+
+# Common variables and flags
+CXX_STD   := c++20
+ICXXFLAGS := -std=$(CXX_STD)
+ICPPFLAGS := -I${THUNDERKITTENS_ROOT}/include -I$(HIP_INCLUDE_DIR)
+ILDFLAGS  :=
+ILDLIBS   :=
+
+CXXFLAGS ?= -Wall -Wextra
+CXXFLAGS := -w
+
+ICXXFLAGS += $(CXXFLAGS)
+ICPPFLAGS += $(CPPFLAGS)
+ILDFLAGS  += $(LDFLAGS)
+ILDLIBS   += $(LDLIBS)
+
+PY_LDFLAGS := $(shell python3-config --ldflags | sed 's/-lcrypt//g')
+ICXXFLAGS += $(PY_LDFLAGS)
+ICXXFLAGS+= -I${THUNDERKITTENS_ROOT}/include -I${THUNDERKITTENS_ROOT}/prototype $(shell python3 -m pybind11 --includes) -shared -fPIC -Rpass-analysis=kernel-resource-usage
+
+
+# Default target
+all: $(TARGET)
+
+LOGDIR := /workdir/data_logs/$(shell date +%m%d_%H%M%S)_outputs
+LOGFILE := $(LOGDIR)/make_build.log
+
+$(TARGET): $(SRC)
+	@mkdir -p $(LOGDIR)
+	$(HIPCXX) $(SRC) $(HIPFLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) \
+	    -o $(TARGET)$(shell python3-config --extension-suffix) 2>&1 | tee $(LOGFILE)
+
+# Clean target
+clean:
+	rm -f $(TARGET)

--- a/kernels/softmax/kernel.cpp
+++ b/kernels/softmax/kernel.cpp
@@ -1,0 +1,76 @@
+#include "kittens.cuh"
+#include "pyutils/pyutils.cuh"
+
+constexpr int B = 64;
+constexpr int N = 8192;
+constexpr int D = 128;
+constexpr int BLOCK_SIZE = 32;
+
+#define NUM_WORKERS (4)
+#define NUM_THREADS (NUM_WORKERS*kittens::WARP_THREADS)
+
+using namespace kittens;
+using shape = kittens::rt_32x32_8_s;
+
+template<int _D> struct softmax_globals {
+    static constexpr int d = _D;
+
+    using x_gl = gl<bf16, -1, -1, -1, -1>;
+    using o_gl = gl<bf16, -1, -1, -1, -1>;
+
+    x_gl x;
+    o_gl o;
+
+    // Each warp handles 32 rows. 4 warps per block = 128 rows per block.
+    dim3 grid() { return dim3(N / (NUM_WORKERS * BLOCK_SIZE), B, 1); }
+    dim3 block() { return dim3(NUM_THREADS); }
+    size_t dynamic_shared_memory() { return 0; }
+};
+
+template<int _D>
+__global__ void softmax_tk(const softmax_globals<_D> g) {
+    auto warpid = kittens::warpid();
+    const int batch = blockIdx.y;
+    const int tile_idx = blockIdx.x * NUM_WORKERS + warpid;
+
+    // 32 rows x 128 cols per warp
+    using tile_t = rt<bf16, BLOCK_SIZE, _D, row_l, shape>;
+    tile_t x_reg;
+    // per-row reduction vectors — must use tile's col_vec type for layout compatibility
+    typename tile_t::col_vec max_vec, sum_vec;
+
+    load<2>(x_reg, g.x, {0, batch, tile_idx, 0});
+    asm volatile("s_waitcnt vmcnt(0)");
+
+    // Step 1: per-row max for numerical stability
+    row_max(max_vec, x_reg);
+
+    // Step 2: subtract max and exponentiate
+    sub_row(x_reg, x_reg, max_vec);
+    exp(x_reg, x_reg);
+
+    // Step 3: per-row sum of exponentials
+    row_sum(sum_vec, x_reg);
+
+    // Step 4: normalize each row
+    div_row(x_reg, x_reg, sum_vec);
+
+    // Store result
+    store(g.o, x_reg, {0, batch, tile_idx, 0});
+}
+
+template<int _D>
+void dispatch_softmax(softmax_globals<_D> g) {
+    unsigned long mem_size = g.dynamic_shared_memory();
+    hipFuncSetAttribute((void*)softmax_tk<_D>, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
+    softmax_tk<_D><<<g.grid(), g.block(), mem_size>>>(g);
+    hipDeviceSynchronize();
+}
+
+PYBIND11_MODULE(tk_kernel, m) {
+    m.doc() = "Softmax HipKittens kernel";
+    py::bind_function<dispatch_softmax<D>>(m, "dispatch_softmax",
+        &softmax_globals<D>::x,
+        &softmax_globals<D>::o
+    );
+}

--- a/kernels/softmax/test_python.py
+++ b/kernels/softmax/test_python.py
@@ -1,0 +1,85 @@
+import torch
+import tk_kernel
+
+B = 64
+N = 8192
+D = 128
+
+torch.random.manual_seed(42)
+x = torch.randn((B, N, D), dtype=torch.bfloat16, device='cuda')
+
+
+def flops(batch, seqlen, dim):
+    # max: N comparisons, sub: N, exp: N, sum: N, div: N => ~5N per row
+    return batch * seqlen * dim * 5
+
+
+def efficiency(flop, time):
+    flop = flop / 1e12
+    time = time / 1e3
+    return flop / time
+
+
+# PyTorch reference
+o_ref = torch.softmax(x.float(), dim=-1).bfloat16()
+
+start_event = torch.cuda.Event(enable_timing=True)
+end_event = torch.cuda.Event(enable_timing=True)
+flops_val = flops(B, N, D)
+num_warmup = 50
+num_iters = 50
+
+
+# Benchmark PyTorch
+print("\nPyTorch:")
+timings = []
+for _ in range(num_warmup):
+    _ = torch.softmax(x, dim=-1)
+for _ in range(num_iters):
+    torch.cuda.synchronize()
+    start_event.record()
+    _ = torch.softmax(x, dim=-1)
+    end_event.record()
+    torch.cuda.synchronize()
+    elapsed_time = start_event.elapsed_time(end_event)
+    timings.append(elapsed_time)
+avg_time_ref = sum(timings) / len(timings)
+eff_ref = efficiency(flops_val, avg_time_ref)
+print(f"PyTorch average execution time: {avg_time_ref:.4f} ms")
+print(f"PyTorch performance: {eff_ref:.2f} TFLOPS for {B=} {N=} {D=}.")
+
+
+# Benchmark HK
+print("\nHK:")
+o_tk = torch.zeros_like(x)
+timings = []
+for _ in range(num_warmup):
+    tk_kernel.dispatch_softmax(x, o_tk)
+for _ in range(num_iters):
+    torch.cuda.synchronize()
+    start_event.record()
+    tk_kernel.dispatch_softmax(x, o_tk)
+    end_event.record()
+    torch.cuda.synchronize()
+    elapsed_time = start_event.elapsed_time(end_event)
+    timings.append(elapsed_time)
+avg_time_tk = sum(timings) / len(timings)
+eff_tk = efficiency(flops_val, avg_time_tk)
+print(f"HK average execution time: {avg_time_tk:.4f} ms")
+print(f"HK performance: {eff_tk:.2f} TFLOPS for {B=} {N=} {D=}.")
+speedup = avg_time_ref / avg_time_tk
+print(f"Speedup from HK: {speedup:.2f}x")
+
+
+# Correctness
+print("\nCorrectness:")
+o_diff = o_ref - o_tk
+max_diff = o_diff.abs().max()
+print(f"max_diff: {max_diff}")
+if max_diff > 0.01:
+    print(f"o_ref:  {o_ref[0, 0, :8]}")
+    print(f"o_tk:   {o_tk[0, 0, :8]}")
+
+# Sanity: rows should sum to ~1.0
+row_sums = o_tk.float().sum(dim=-1)
+print(f"Row sum min: {row_sums.min():.4f}, max: {row_sums.max():.4f} (should be ~1.0)")


### PR DESCRIPTION
## Summary
- Adds a standalone softmax kernel using HipKittens register tiles (`rt<bf16, 32, 128>`)
- 1.33x faster than PyTorch on MI350X at B=64, N=8192, D=128

## Results (MI350X, gfx950)
| | Time (ms) | TFLOPS | vs PyTorch |
|---|---|---|---|
| PyTorch | 0.110 | 3.05 | 1.00x |
| HK softmax | 0.083 | 4.07 | **1.33x** |

Correctness: max_diff = 0.008 (bf16 precision), row sums ≈ 1.0