### PR TITLE
Fix unsatisfiable bf16 GEMM test tolerance (fp32 ref + atol floor)

### DIFF
--- a/kernels/gemm/bf16fp32/test.py
+++ b/kernels/gemm/bf16fp32/test.py
@@ -26,9 +26,9 @@ if __name__ == "__main__":
         Bt = B.t().contiguous()
         C = init_empty((m, n), dtype, device)
 
-        C_ref = torch.matmul(A, B)
+        C_ref = torch.matmul(A.float(), B.float())   # fp32 reference
         tk_kernel.dispatch_micro(A, Bt, C)
 
-        is_valid = torch.allclose(C, C_ref, rtol=1e-2)
+        is_valid = torch.allclose(C.float(), C_ref, rtol=1e-2, atol=1e-1)
         result = "TEST PASSED" if is_valid else "TEST FAILED"
         print(f"{test_shape}".ljust(18) + f" | {result}")


### PR DESCRIPTION
The GEMM test uses `allclose(C, C_ref, rtol=1e-2)` — "match within 1%". But 1% is a percentage *of each value*, so tiny outputs get an almost-zero allowance.

A GEMM adds up thousands of terms; when they nearly cancel, the result is tiny but the normal rounding difference (the kernel and rocBLAS add in a different order) stays the same size. That difference is a large *percentage* of a tiny number, so a correct kernel gets marked FAILED. The check is so strict it even fails torch's own output against the exact answer.

Fix: compare to the exact (fp32) result, and allow a small fixed difference on top of the percentage:
`allclose(C.float(), A.float()@B.float(), rtol=1e-2, atol=1e-1)`.
