### PR TITLE
Guard unsupported shapes in base GEMM dispatch (M,N % 256; K % 128)

### DIFF
--- a/kernels/gemm/bf16fp32/256_256_64_32_with16x32.cpp
+++ b/kernels/gemm/bf16fp32/256_256_64_32_with16x32.cpp
@@ -1,5 +1,6 @@
 #include "kittens.cuh"
 #include "pyutils/pyutils.cuh"
+#include <stdexcept>
 using namespace kittens;
 
 constexpr int BLOCK_SIZE       = 256;  
@@ -327,6 +328,10 @@ void micro_tk(const micro_globals g, int M, int N, int K) {
 }
 
 void dispatch_micro(micro_globals g) {
+    if (g.M % BLOCK_SIZE || g.N % BLOCK_SIZE)
+        throw std::runtime_error("GEMM: M and N must be multiples of BLOCK_SIZE (256)");
+    if (g.K % (2 * K_STEP))
+        throw std::runtime_error("GEMM: K must be a multiple of 128 (mainloop consumes K-slices in pairs of K_STEP=64; K%64 is not sufficient)");
     unsigned long mem_size = g.dynamic_shared_memory();
     hipFuncSetAttribute((void*)micro_tk, hipFuncAttributeMaxDynamicSharedMemorySize, mem_size);
     micro_tk<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M, g.N, g.K);


### PR DESCRIPTION
The hand-scheduled GEMM mainloop needs `M, N` to be multiples of 256 and consumes K in pairs of 64, so it really requires `K % 128 == 0` — but the documented contract said `K % 64` and nothing checked it. An odd K-slice count (e.g. `K = 192`) silently returns wrong results and reads out of bounds.

This adds host-side checks in `dispatch_micro` so an unsupported shape raises a clear error instead of producing garbage. No kernel-logic change.
