### PR TITLE
Track header dependencies in kernel builds (-MMD -MP)

### DIFF
--- a/kernels/common.mk
+++ b/kernels/common.mk
@@ -70,22 +70,26 @@ BUILD_DIR ?= build
 
 ifneq ($(CUSTOM_RULES),1)
 ifeq ($(BUILD_MODE),pyext)
+DEPFILE := $(TARGET).d
 all: $(TARGET)
 
+-include $(DEPFILE)
 $(TARGET): $(SRC)
 	$(HIPCXX) $(SRC) $(HIPFLAGS) $(ICXXFLAGS) $(ICPPFLAGS) $(ILDFLAGS) $(ILDLIBS) \
-		-o $(TARGET)$(PY_EXT_SUFFIX)
+		-MMD -MP -MF $(DEPFILE) -o $(TARGET)$(PY_EXT_SUFFIX)
 
 clean:
-	rm -f $(TARGET) $(TARGET).*so
+	rm -f $(TARGET) $(TARGET).*so $(DEPFILE)
 else ifeq ($(BUILD_MODE),standalone)
 OBJ ?= $(BUILD_DIR)/$(notdir $(basename $(SRC))).o
+DEPFILE := $(OBJ:.o=.d)
 
 all: $(TARGET)
 
+-include $(DEPFILE)
 $(TARGET): $(SRC)
 	mkdir -p $(BUILD_DIR)
-	$(HIPCXX) $(HIPFLAGS) $(ICXXFLAGS) $(ICPPFLAGS) -c $(SRC) -o $(OBJ)
+	$(HIPCXX) $(HIPFLAGS) $(ICXXFLAGS) $(ICPPFLAGS) -MMD -MP -MF $(DEPFILE) -c $(SRC) -o $(OBJ)
 	$(HIPCXX) $(HIPFLAGS) $(ILDFLAGS) $(ILDLIBS) $(OBJ) -o $(TARGET)
 
 clean:


### PR DESCRIPTION
The kernel build rules depend only on the `.cpp` source, so editing a `.cuh` header doesn't trigger a rebuild — `make` is a no-op and you silently run/test a **stale** `.so` (this costs real debug cycles, since most kernel logic lives in headers).

This emits and `-include`s depfiles (`-MMD -MP -MF`) in both the `pyext` and `standalone` rules, so editing any header rebuilds correctly. Verified with `make -n` (the compile line now carries `-MMD -MP -MF`, and the Makefile parses clean).
