### PR TITLE
Fix LDS reuse hazard in MXFP8 4-wave GEMM kernel

### DIFF
--- a/kernels/gemm/mxfp8/MXFP8_4wave/4_wave.cu
+++ b/kernels/gemm/mxfp8/MXFP8_4wave/4_wave.cu
@@ -181,6 +181,7 @@ void mxfp8_gemm_4wave_kernel(
         auto a_subtile_1 = kittens::subtile_inplace<REG_M, BLOCK_K>(As[curr][1], {warp_m, 0});
         load(a[1], a_subtile_1);
         G::load(Bs[curr][1], B, {0, 0, block_col * 2 + 1, k + 2});
+        asm volatile("s_waitcnt lgkmcnt(0)");
         G::load(As[curr][1], A, {0, 0, block_row * 2 + 1, k + 2});
 
         mma_ABt_scaled_16(cB, a[0], b[1], &sa_h0, &sb_h1);


### PR DESCRIPTION
## Summary

The 4-wave MXFP8 GEMM exhibited a correctness failure on the default 8192×8192×8192 shape. Investigation pointed to a potential synchronization issue when reusing the `As[curr][1]` LDS region before completion of the corresponding register-tile load.

Add an explicit `s_waitcnt lgkmcnt(0)` before refilling `As[curr][1]` to ensure outstanding LDS reads have completed before the LDS buffer is reused.

## Validation

Verified correctness for square shapes:

* 8192×8192×8192
* 12288×12288×12288
* 16384×16384×16384

## Platform

MI355X
