### PR TITLE
Add gfx1250 st_16x64 shared tile shape

### DIFF
--- a/include/udna1/types/shared/st_shape.cuh
+++ b/include/udna1/types/shared/st_shape.cuh
@@ -205,6 +205,23 @@ struct st_8x32 {
     }
 };
 
+struct st_16x64 {
+    static constexpr int rows = 16;
+    static constexpr int cols = 64;
+
+    template<typename _T>
+    static constexpr int bytes_per_thread() {
+        static_assert(sizeof(_T) == 1 || sizeof(_T) == 2 || sizeof(_T) == 4, "Unsupported type");
+        return 16;
+    }
+
+    template<typename _T>
+    __device__ __forceinline__ static const uint32_t swizzle (int2 coord) {
+        static_assert(sizeof(_T) == 1 || sizeof(_T) == 2 || sizeof(_T) == 4, "Unsupported type");
+        return sizeof(_T) * (coord.x * cols + coord.y);
+    }
+};
+
 struct st_16x128 {
     static constexpr int rows = 16;
     static constexpr int cols = 128;
@@ -296,6 +313,7 @@ concept all = std::is_same_v<T, st_16x16> ||
               std::is_same_v<T, st_16x32> || 
               std::is_same_v<T, st_32x16> || 
               std::is_same_v<T, st_8x32>  ||
+              std::is_same_v<T, st_16x64> ||
               std::is_same_v<T, st_16x128> ||
               std::is_same_v<T, st_16x32_padded<>> ||
               std::is_same_v<T, st_16x32_padded<128, 8>> ||


### PR DESCRIPTION
## Summary
- Add the missing `st_16x64` shared tile shape to the UDNA1/gfx1250 shared tile descriptors.
- Register the new shape in the `st_shape::all` concept so the existing `st_16x64_s` alias is valid.

## Test plan
- Compiled a focused HIP check including `udna1/common/common.cuh` and `udna1/types/types.cuh` with `-DKITTENS_UDNA1 --offload-arch=gfx1250`, asserting `st_shape::all<kittens::st_16x64_s>`.
- Attempted `make KERNEL=gemm_naive` in `kernels/gemm/bf16fp32/gfx1250`; it now gets past the missing `st_16x64` type and stops on an existing `__builtin_amdgcn_tensor_load_to_lds` signature issue in `include/udna1/ops/warp/memory/tile/global_to_shared.cuh`.


Made with [Cursor](https://cursor.com)