### PR TITLE
Lane-ordering for MXFP8 GEMM scales

### DIFF
--- a/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_NN.cu
+++ b/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_NN.cu
@@ -34,6 +34,41 @@ constexpr int REG_N      = BLOCK_COL / WARPS_COL / 2;
 
 using G = kittens::group<NUM_WARPS>;
 
+using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
+
+// Reads the pre-packed lane-native scale for group lg on this lane (single LDS load, zero ALU).
+__device__ __forceinline__ fp8e8m0_4 lane_rd(const ST_Scale &s, int lg) {
+    return reinterpret_cast<const uint32_t *>(s.data)[lg * 64 + laneid()];
+}
+
+// Repacks the iteration-major scale buffer into the lane-native layout the kernel reads:
+// one fp8e8m0_4 per (group, lane), computed once via the same pack_scales the loop used to run.
+// One block per 256-row tile; A uses STEP=64,NG=4, B uses STEP=32,NG=8.
+template<int STEP, int NG>
+__global__ void pack_scales_lane_kernel(const uint32_t *__restrict__ packed,
+                                        uint32_t *__restrict__ ln, int num_tiles) {
+    constexpr int TILE_WORDS = 256;
+    constexpr int PAD_WORDS  = (NG - 1) * STEP + 64;  // covers max OOB pack_scales read
+    __shared__ uint32_t tile[PAD_WORDS];
+
+    int t = blockIdx.x;
+    if (t >= num_tiles) return;
+    int lane = threadIdx.x % 64;
+    int grp  = threadIdx.x / 64;
+
+    for (int i = threadIdx.x; i < PAD_WORDS; i += blockDim.x)
+        tile[i] = (i < TILE_WORDS) ? packed[(size_t)t * TILE_WORDS + i] : 0u;
+    __syncthreads();
+
+    fp8e8m0_4 out = pack_scales((const fp8e8m0 *)tile, grp * STEP);
+    ln[((size_t)t * NG + grp) * 64 + lane] = out;
+}
+
+template<int STEP, int NG>
+static void launch_pack_scales_lane(const uint32_t *packed, uint32_t *ln, int num_tiles) {
+    pack_scales_lane_kernel<STEP, NG><<<num_tiles, NG * 64>>>(packed, ln, num_tiles);
+}
+
 template <int M, int N, int K>
 __global__ __launch_bounds__(512, 2)
 void mxfp8_gemm_kernel(
@@ -47,14 +82,14 @@ void mxfp8_gemm_kernel(
 
     using ST_A     = st_fp8e4m3<BLOCK_K, HALF_ROW, st_16x128_s>;
     using ST_B     = st_fp8e4m3<HALF_COL, BLOCK_K, st_16x128_s>;
-    using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
     using RT_A     = rt<fp8e4m3, REG_M, BLOCK_K, col_l, rt_16x128_s>;
     using RT_B     = rt_fp8e4m3<REG_N, BLOCK_K>;
     using RT_C     = rt_fl<REG_M, REG_N, col_l, rt_16x16_s>;
 
     __shared__ ST_A As[2][2];
     __shared__ ST_B Bs[2][2];
-    __shared__ ST_Scale scale_A_smem[2], scale_B_smem[2];
+    // B needs 8 scale groups = 2 tiles: scale_B_lo holds groups 0-3, scale_B_hi groups 4-7.
+    __shared__ ST_Scale scale_A_smem[2], scale_B_lo[2], scale_B_hi[2];
 
     RT_A a;
     RT_B b0, b1;
@@ -87,31 +122,47 @@ void mxfp8_gemm_kernel(
     G::prefill_swizzled_offsets(As[0][0], A, sw_A);
     G::prefill_swizzled_offsets(Bs[0][0], B, sw_B);
 
-    int a_row_h0  = warp_m * REG_M;
-    int a_row_h1  = HALF_ROW + warp_m * REG_M;
-    int b_row_h0  = warp_n * REG_N;
-    int b_row_h1  = HALF_COL + warp_n * REG_N;
+    // SRD buffer loads: uniform base+stride in SGPRs, avoiding the per-thread VGPR address
+    // math (plain G::load spills 4 VGPRs, which sinks the lane-scale win).
+    const T *a_base = (const T *)&A[{0, 0, 0, 0}];
+    const T *b_base = (const T *)&B[{0, 0, 0, 0}];
+    const int a_row_stride = A.template stride<2>() * sizeof(T);
+    const int b_row_stride = B.template stride<2>() * sizeof(T);
+    i32x4 a_srd = make_srsrc(a_base, A.rows() * a_row_stride, a_row_stride);
+    i32x4 b_srd = make_srsrc(b_base, B.rows() * b_row_stride, b_row_stride);
+
+    const int wid = warpid() % NUM_WARPS;
+    constexpr int elem_per_warp = (16 / sizeof(T)) * kittens::WARP_THREADS;
+    uint32_t a_lds[2][2], b_lds[2][2];
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 2; j++) {
+        a_lds[i][j] = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(&As[i][j].data[0]) + wid * elem_per_warp * sizeof(T)));
+        b_lds[i][j] = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(&Bs[i][j].data[0]) + wid * elem_per_warp * sizeof(T)));
+    }
+
     int a_col_off = warp_m * REG_M;
 
     int tic = 0, toc = 1;
     int tic_scales = 0, toc_scales = 1;
 
-    G::load(Bs[tic][0], B, {0, 0, block_col * 2,     0}, sw_B);
-    G::load(As[tic][0], A, {0, 0, 0, block_row * 2    }, sw_A);
-    G::load(Bs[tic][1], B, {0, 0, block_col * 2 + 1,  0}, sw_B);
-    G::load(As[tic][1], A, {0, 0, 0, block_row * 2 + 1}, sw_A);
+    G::load(Bs[tic][0], B, {0, 0, block_col * 2,     0}, sw_B, b_srd, b_base, b_lds[tic][0]);
+    G::load(As[tic][0], A, {0, 0, 0, block_row * 2    }, sw_A, a_srd, a_base, a_lds[tic][0]);
+    G::load(Bs[tic][1], B, {0, 0, block_col * 2 + 1, 0}, sw_B, b_srd, b_base, b_lds[tic][1]);
+    G::load(As[tic][1], A, {0, 0, 0, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[tic][1]);
 
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
 
-    G::load(As[toc][0], A, {0, 0, 1, block_row * 2    }, sw_A);
-    G::load(Bs[toc][0], B, {0, 0, block_col * 2,     1}, sw_B);
-    G::load(Bs[toc][1], B, {0, 0, block_col * 2 + 1, 1}, sw_B);
+    G::load(As[toc][0], A, {0, 0, 1, block_row * 2    }, sw_A, a_srd, a_base, a_lds[toc][0]);
+    G::load(Bs[toc][0], B, {0, 0, block_col * 2,     1}, sw_B, b_srd, b_base, b_lds[toc][0]);
+    G::load(Bs[toc][1], B, {0, 0, block_col * 2 + 1, 1}, sw_B, b_srd, b_base, b_lds[toc][1]);
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
 
-    G::load(scale_A_smem[0], scale_A_gl, {0 * tiles_M + block_row, 0, 0, 0});
-    G::load(scale_B_smem[0], scale_B_gl, {0 * tiles_N + block_col, 0, 0, 0});
+    G::load(scale_A_smem[0], scale_A_gl, {block_row, 0, 0, 0});
+    G::load(scale_B_lo[0],   scale_B_gl, {2 * block_col,     0, 0, 0});
+    G::load(scale_B_hi[0],   scale_B_gl, {2 * block_col + 1, 0, 0, 0});
     asm volatile("s_waitcnt vmcnt(0)");
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
@@ -122,28 +173,29 @@ void mxfp8_gemm_kernel(
     for (int k = 0; k < k_iters - 2; k++, tic ^= 1, toc ^= 1, tic_scales ^= 1, toc_scales ^= 1) {
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
 
         auto bs0 = subtile_inplace<REG_N, BLOCK_K>(Bs[tic][0], {warp_n, 0});
         load(b0, bs0);
         load(a, As[tic][0], a_col_off);
-        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A);
+        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[toc][1]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
         __builtin_amdgcn_s_setprio(2);
         mma_ABt_scaled(cA, a, b0, cA, &sa_h0, &sb_h0);
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
 
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
         auto bs1 = subtile_inplace<REG_N, BLOCK_K>(Bs[tic][1], {warp_n, 0});
         load(b1, bs1);
-        G::load(As[tic][0], A, {0, 0, k + 2, block_row * 2    }, sw_A);
+        G::load(As[tic][0], A, {0, 0, k + 2, block_row * 2}, sw_A, a_srd, a_base, a_lds[tic][0]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
@@ -152,9 +204,9 @@ void mxfp8_gemm_kernel(
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_s_barrier();
 
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
         load(a, As[tic][1], a_col_off);
-        G::load(Bs[tic][0], B, {0, 0, block_col * 2,    k + 2}, sw_B);
+        G::load(Bs[tic][0], B, {0, 0, block_col * 2, k + 2}, sw_B, b_srd, b_base, b_lds[tic][0]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
@@ -164,7 +216,7 @@ void mxfp8_gemm_kernel(
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
 
-        G::load(Bs[tic][1], B, {0, 0, block_col * 2 + 1, k + 2}, sw_B);
+        G::load(Bs[tic][1], B, {0, 0, block_col * 2 + 1, k + 2}, sw_B, b_srd, b_base, b_lds[tic][1]);
         asm volatile("s_waitcnt vmcnt(6)");
         __builtin_amdgcn_s_barrier();
 
@@ -178,21 +230,22 @@ void mxfp8_gemm_kernel(
         int k = k_iters - 2;
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         auto bs0 = subtile_inplace<REG_N, BLOCK_K>(Bs[tic][0], {warp_n, 0});
         load(b0, bs0);
         load(a, As[tic][0], a_col_off);
-        G::load(As[toc][0], A, {0, 0, k + 1, block_row * 2    }, sw_A);
-        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A);
+        G::load(As[toc][0], A, {0, 0, k + 1, block_row * 2    }, sw_A, a_srd, a_base, a_lds[toc][0]);
+        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[toc][1]);
         __builtin_amdgcn_s_barrier();
 
         asm volatile("s_waitcnt lgkmcnt(0)");
@@ -241,10 +294,10 @@ void mxfp8_gemm_kernel(
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         load(a, As[tic][0], a_col_off);
         __builtin_amdgcn_s_barrier();
@@ -368,32 +421,39 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     std::vector<uint8_t> sa_raw, sb_raw;
     std::vector<uint32_t> sa_iter, sb_iter;
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a, (size_t)ROTATING_BUFFER_COUNT * K * M);
     hipMalloc(&d_b, (size_t)ROTATING_BUFFER_COUNT * N * K);
     hipMalloc(&d_c, (size_t)M * N * sizeof(float));
-    hipMalloc(&d_sa, (size_t)ROTATING_BUFFER_COUNT * k_iters * M * sizeof(uint32_t));
-    hipMalloc(&d_sb, (size_t)ROTATING_BUFFER_COUNT * k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));  // iteration-major staging
+    hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    // Lane-native buffers (A: 256 words/tile, B: 512 words/tile), one per rotating buffer.
+    hipMalloc(&d_sa_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_N * 512 * sizeof(uint32_t));
     HipCheckError();
 
     for (int buf = 0; buf < ROTATING_BUFFER_COUNT; buf++) {
         random_init_mxfp8<M, N, K>(a_f, b_f, a_q, b_q, a_q_km, sa_raw, sb_raw, sa_iter, sb_iter, 42 + buf);
         hipMemcpy(d_a  + (size_t)buf * K * M, a_q_km.data(), (size_t)K * M, hipMemcpyHostToDevice);
         hipMemcpy(d_b  + (size_t)buf * N * K, b_q.data(), (size_t)N * K, hipMemcpyHostToDevice);
-        hipMemcpy(d_sa + (size_t)buf * k_iters * M, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
-        hipMemcpy(d_sb + (size_t)buf * k_iters * N, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sa, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sb, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln + (size_t)buf * k_iters * tiles_M * 256, k_iters * tiles_M);
+        launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln + (size_t)buf * k_iters * tiles_N * 512, k_iters * tiles_N);
     }
+    hipDeviceSynchronize();
     HipCheckError();
 
-    constexpr int tiles_M = M / BLOCK_ROW;
-    constexpr int tiles_N = N / BLOCK_COL;
     for (int i = 0; i < warmup_iters; i++) {
         int buf = i % ROTATING_BUFFER_COUNT;
         gl<fp8e4m3, 1, 1, K, M> A(d_a + (size_t)buf * K * M, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, N, K> B(d_b + (size_t)buf * N * K, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipDeviceSynchronize();
     }
@@ -406,8 +466,8 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
         gl<fp8e4m3, 1, 1, K, M> A(d_a + (size_t)buf * K * M, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, N, K> B(d_b + (size_t)buf * N * K, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         hipEventRecord(t0);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipEventRecord(t1);
@@ -421,7 +481,7 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     double ops = 2.0 * M * N * K;
 
     hipEventDestroy(t0); hipEventDestroy(t1);
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     return { best, avg, ops / (best * 1e-3) / 1e12, ops / (avg * 1e-3) / 1e12, timing_iters };
 }
@@ -457,23 +517,30 @@ bool run_correctness() {
             c_ref[(size_t)i * N + j] = acc;
         }
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a,  (size_t)K * M);
     hipMalloc(&d_b,  (size_t)N * K);
     hipMalloc(&d_c,  MN * sizeof(float));
     hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));
     hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa_ln, (size_t)k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)k_iters * tiles_N * 512 * sizeof(uint32_t));
     hipMemcpy(d_a,  a_q_km.data(),  (size_t)K * M, hipMemcpyHostToDevice);
     hipMemcpy(d_b,  b_q.data(),     (size_t)N * K, hipMemcpyHostToDevice);
     hipMemcpy(d_sa, sa_iter.data(),  (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemcpy(d_sb, sb_iter.data(),  (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemset(d_c, 0, MN * sizeof(float));
+    launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln, k_iters * tiles_M);
+    launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln, k_iters * tiles_N);
+    hipDeviceSynchronize();
 
     gl<fp8e4m3, 1, 1, K, M> A_gl(d_a, nullptr, nullptr, nullptr, nullptr);
     gl<fp8e4m3, 1, 1, N, K> B_gl(d_b, nullptr, nullptr, nullptr, nullptr);
     gl<float,   1, 1, M, N> C_gl(d_c, nullptr, nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa), k_iters * (M / BLOCK_ROW), nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb), k_iters * (N / BLOCK_COL), nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa_ln), k_iters * tiles_M, nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb_ln), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
     mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A_gl, B_gl, C_gl, SA_gl, SB_gl);
     hipDeviceSynchronize();
 
@@ -487,7 +554,7 @@ bool run_correctness() {
     for (size_t i = 0; i < MN; i++)
         if (std::abs(c_gpu[i] - c_ref[i]) > atol) fail_count++;
 
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     printf("  atol (0.1%%): %.2e -> %d / %zu failures -> %s\n",
            atol, fail_count, MN, fail_count == 0 ? "PASS" : "FAIL");

--- a/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_NT.cu
+++ b/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_NT.cu
@@ -34,6 +34,41 @@ constexpr int REG_N      = BLOCK_COL / WARPS_COL / 2;
 
 using G = kittens::group<NUM_WARPS>;
 
+using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
+
+// Reads the pre-packed lane-native scale for group lg on this lane (single LDS load, zero ALU).
+__device__ __forceinline__ fp8e8m0_4 lane_rd(const ST_Scale &s, int lg) {
+    return reinterpret_cast<const uint32_t *>(s.data)[lg * 64 + laneid()];
+}
+
+// Repacks the iteration-major scale buffer into the lane-native layout the kernel reads:
+// one fp8e8m0_4 per (group, lane), computed once via the same pack_scales the loop used to run.
+// One block per 256-row tile; A uses STEP=64,NG=4, B uses STEP=32,NG=8.
+template<int STEP, int NG>
+__global__ void pack_scales_lane_kernel(const uint32_t *__restrict__ packed,
+                                        uint32_t *__restrict__ ln, int num_tiles) {
+    constexpr int TILE_WORDS = 256;
+    constexpr int PAD_WORDS  = (NG - 1) * STEP + 64;  // covers max OOB pack_scales read
+    __shared__ uint32_t tile[PAD_WORDS];
+
+    int t = blockIdx.x;
+    if (t >= num_tiles) return;
+    int lane = threadIdx.x % 64;
+    int grp  = threadIdx.x / 64;
+
+    for (int i = threadIdx.x; i < PAD_WORDS; i += blockDim.x)
+        tile[i] = (i < TILE_WORDS) ? packed[(size_t)t * TILE_WORDS + i] : 0u;
+    __syncthreads();
+
+    fp8e8m0_4 out = pack_scales((const fp8e8m0 *)tile, grp * STEP);
+    ln[((size_t)t * NG + grp) * 64 + lane] = out;
+}
+
+template<int STEP, int NG>
+static void launch_pack_scales_lane(const uint32_t *packed, uint32_t *ln, int num_tiles) {
+    pack_scales_lane_kernel<STEP, NG><<<num_tiles, NG * 64>>>(packed, ln, num_tiles);
+}
+
 template <int M, int N, int K>
 __global__ __launch_bounds__(512, 2)
 void mxfp8_gemm_kernel(
@@ -47,14 +82,14 @@ void mxfp8_gemm_kernel(
 
     using ST_A     = st_fp8e4m3<BLOCK_K, HALF_ROW, st_16x128_s>;
     using ST_B     = st_fp8e4m3<BLOCK_K, HALF_COL, st_16x128_s>;
-    using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
     using RT_A     = rt<fp8e4m3, REG_M, BLOCK_K, col_l, rt_16x128_s>;
     using RT_B     = rt<fp8e4m3, REG_N, BLOCK_K, col_l, rt_16x128_s>;
     using RT_C     = rt_fl<REG_M, REG_N, col_l, rt_16x16_s>;
 
     __shared__ ST_A As[2][2];
     __shared__ ST_B Bs[2][2];
-    __shared__ ST_Scale scale_A_smem[2], scale_B_smem[2];
+    // B needs 8 scale groups = 2 tiles: scale_B_lo holds groups 0-3, scale_B_hi groups 4-7.
+    __shared__ ST_Scale scale_A_smem[2], scale_B_lo[2], scale_B_hi[2];
 
     RT_A a;
     RT_B b0, b1;
@@ -87,32 +122,48 @@ void mxfp8_gemm_kernel(
     G::prefill_swizzled_offsets(As[0][0], A, sw_A);
     G::prefill_swizzled_offsets(Bs[0][0], B, sw_B);
 
-    int a_row_h0  = warp_m * REG_M;
-    int a_row_h1  = HALF_ROW + warp_m * REG_M;
-    int b_row_h0  = warp_n * REG_N;
-    int b_row_h1  = HALF_COL + warp_n * REG_N;
+    // SRD buffer loads: uniform base+stride in SGPRs, avoiding the per-thread VGPR address
+    // math (plain G::load spills 7 VGPRs, which sinks the lane-scale win).
+    const T *a_base = (const T *)&A[{0, 0, 0, 0}];
+    const T *b_base = (const T *)&B[{0, 0, 0, 0}];
+    const int a_row_stride = A.template stride<2>() * sizeof(T);
+    const int b_row_stride = B.template stride<2>() * sizeof(T);
+    i32x4 a_srd = make_srsrc(a_base, A.rows() * a_row_stride, a_row_stride);
+    i32x4 b_srd = make_srsrc(b_base, B.rows() * b_row_stride, b_row_stride);
+
+    const int wid = warpid() % NUM_WARPS;
+    constexpr int elem_per_warp = (16 / sizeof(T)) * kittens::WARP_THREADS;
+    uint32_t a_lds[2][2], b_lds[2][2];
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 2; j++) {
+        a_lds[i][j] = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(&As[i][j].data[0]) + wid * elem_per_warp * sizeof(T)));
+        b_lds[i][j] = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(
+            reinterpret_cast<uintptr_t>(&Bs[i][j].data[0]) + wid * elem_per_warp * sizeof(T)));
+    }
+
     int a_col_off = warp_m * REG_M;
     int b_col_off = warp_n * REG_N;
 
     int tic = 0, toc = 1;
     int tic_scales = 0, toc_scales = 1;
 
-    G::load(Bs[tic][0], B, {0, 0, 0, block_col * 2    }, sw_B);
-    G::load(As[tic][0], A, {0, 0, 0, block_row * 2    }, sw_A);
-    G::load(Bs[tic][1], B, {0, 0, 0, block_col * 2 + 1}, sw_B);
-    G::load(As[tic][1], A, {0, 0, 0, block_row * 2 + 1}, sw_A);
+    G::load(Bs[tic][0], B, {0, 0, 0, block_col * 2    }, sw_B, b_srd, b_base, b_lds[tic][0]);
+    G::load(As[tic][0], A, {0, 0, 0, block_row * 2    }, sw_A, a_srd, a_base, a_lds[tic][0]);
+    G::load(Bs[tic][1], B, {0, 0, 0, block_col * 2 + 1}, sw_B, b_srd, b_base, b_lds[tic][1]);
+    G::load(As[tic][1], A, {0, 0, 0, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[tic][1]);
 
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
 
-    G::load(As[toc][0], A, {0, 0, 1, block_row * 2    }, sw_A);
-    G::load(Bs[toc][0], B, {0, 0, 1, block_col * 2    }, sw_B);
-    G::load(Bs[toc][1], B, {0, 0, 1, block_col * 2 + 1}, sw_B);
+    G::load(As[toc][0], A, {0, 0, 1, block_row * 2    }, sw_A, a_srd, a_base, a_lds[toc][0]);
+    G::load(Bs[toc][0], B, {0, 0, 1, block_col * 2    }, sw_B, b_srd, b_base, b_lds[toc][0]);
+    G::load(Bs[toc][1], B, {0, 0, 1, block_col * 2 + 1}, sw_B, b_srd, b_base, b_lds[toc][1]);
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
 
-    G::load(scale_A_smem[0], scale_A_gl, {0 * tiles_M + block_row, 0, 0, 0});
-    G::load(scale_B_smem[0], scale_B_gl, {0 * tiles_N + block_col, 0, 0, 0});
+    G::load(scale_A_smem[0], scale_A_gl, {block_row, 0, 0, 0});
+    G::load(scale_B_lo[0],   scale_B_gl, {2 * block_col,     0, 0, 0});
+    G::load(scale_B_hi[0],   scale_B_gl, {2 * block_col + 1, 0, 0, 0});
     asm volatile("s_waitcnt vmcnt(0)");
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
@@ -123,26 +174,27 @@ void mxfp8_gemm_kernel(
     for (int k = 0; k < k_iters - 2; k++, tic ^= 1, toc ^= 1, tic_scales ^= 1, toc_scales ^= 1) {
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
 
         load(b0, Bs[tic][0], b_col_off);
         load(a, As[tic][0], a_col_off);
-        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A);
+        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[toc][1]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
         __builtin_amdgcn_s_setprio(2);
         mma_ABt_scaled(cA, a, b0, cA, &sa_h0, &sb_h0);
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
 
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
         load(b1, Bs[tic][1], b_col_off);
-        G::load(As[tic][0], A, {0, 0, k + 2, block_row * 2    }, sw_A);
+        G::load(As[tic][0], A, {0, 0, k + 2, block_row * 2}, sw_A, a_srd, a_base, a_lds[tic][0]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
@@ -151,9 +203,9 @@ void mxfp8_gemm_kernel(
         __builtin_amdgcn_s_setprio(0);
         __builtin_amdgcn_s_barrier();
 
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
         load(a, As[tic][1], a_col_off);
-        G::load(Bs[tic][0], B, {0, 0, k + 2, block_col * 2    }, sw_B);
+        G::load(Bs[tic][0], B, {0, 0, k + 2, block_col * 2}, sw_B, b_srd, b_base, b_lds[tic][0]);
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
 
@@ -163,7 +215,7 @@ void mxfp8_gemm_kernel(
         __builtin_amdgcn_s_barrier();
         __builtin_amdgcn_sched_barrier(0);
 
-        G::load(Bs[tic][1], B, {0, 0, k + 2, block_col * 2 + 1}, sw_B);
+        G::load(Bs[tic][1], B, {0, 0, k + 2, block_col * 2 + 1}, sw_B, b_srd, b_base, b_lds[tic][1]);
         asm volatile("s_waitcnt vmcnt(6)");
         __builtin_amdgcn_s_barrier();
 
@@ -177,20 +229,21 @@ void mxfp8_gemm_kernel(
         int k = k_iters - 2;
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         load(b0, Bs[tic][0], b_col_off);
         load(a, As[tic][0], a_col_off);
-        G::load(As[toc][0], A, {0, 0, k + 1, block_row * 2    }, sw_A);
-        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A);
+        G::load(As[toc][0], A, {0, 0, k + 1, block_row * 2    }, sw_A, a_srd, a_base, a_lds[toc][0]);
+        G::load(As[toc][1], A, {0, 0, k + 1, block_row * 2 + 1}, sw_A, a_srd, a_base, a_lds[toc][1]);
         __builtin_amdgcn_s_barrier();
 
         asm volatile("s_waitcnt lgkmcnt(0)");
@@ -237,10 +290,10 @@ void mxfp8_gemm_kernel(
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         load(a, As[tic][0], a_col_off);
         __builtin_amdgcn_s_barrier();
@@ -369,32 +422,39 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     std::vector<uint8_t> sa_raw, sb_raw;
     std::vector<uint32_t> sa_iter, sb_iter;
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a, (size_t)ROTATING_BUFFER_COUNT * K * M);
     hipMalloc(&d_b, (size_t)ROTATING_BUFFER_COUNT * K * N);
     hipMalloc(&d_c, (size_t)M * N * sizeof(float));
-    hipMalloc(&d_sa, (size_t)ROTATING_BUFFER_COUNT * k_iters * M * sizeof(uint32_t));
-    hipMalloc(&d_sb, (size_t)ROTATING_BUFFER_COUNT * k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));  // iteration-major staging
+    hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    // Lane-native buffers (A: 256 words/tile, B: 512 words/tile), one per rotating buffer.
+    hipMalloc(&d_sa_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_N * 512 * sizeof(uint32_t));
     HipCheckError();
 
     for (int buf = 0; buf < ROTATING_BUFFER_COUNT; buf++) {
         random_init_mxfp8<M, N, K>(a_f, b_f, a_q, b_q, a_q_km, b_q_kn, sa_raw, sb_raw, sa_iter, sb_iter, 42 + buf);
         hipMemcpy(d_a  + (size_t)buf * K * M, a_q_km.data(), (size_t)K * M, hipMemcpyHostToDevice);
         hipMemcpy(d_b  + (size_t)buf * K * N, b_q_kn.data(), (size_t)K * N, hipMemcpyHostToDevice);
-        hipMemcpy(d_sa + (size_t)buf * k_iters * M, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
-        hipMemcpy(d_sb + (size_t)buf * k_iters * N, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sa, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sb, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln + (size_t)buf * k_iters * tiles_M * 256, k_iters * tiles_M);
+        launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln + (size_t)buf * k_iters * tiles_N * 512, k_iters * tiles_N);
     }
+    hipDeviceSynchronize();
     HipCheckError();
 
-    constexpr int tiles_M = M / BLOCK_ROW;
-    constexpr int tiles_N = N / BLOCK_COL;
     for (int i = 0; i < warmup_iters; i++) {
         int buf = i % ROTATING_BUFFER_COUNT;
         gl<fp8e4m3, 1, 1, K, M> A(d_a + (size_t)buf * K * M, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, K, N> B(d_b + (size_t)buf * K * N, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipDeviceSynchronize();
     }
@@ -407,8 +467,8 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
         gl<fp8e4m3, 1, 1, K, M> A(d_a + (size_t)buf * K * M, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, K, N> B(d_b + (size_t)buf * K * N, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         hipEventRecord(t0);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipEventRecord(t1);
@@ -422,7 +482,7 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     double ops = 2.0 * M * N * K;
 
     hipEventDestroy(t0); hipEventDestroy(t1);
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     return { best, avg, ops / (best * 1e-3) / 1e12, ops / (avg * 1e-3) / 1e12, timing_iters };
 }
@@ -458,23 +518,30 @@ bool run_correctness() {
             c_ref[(size_t)i * N + j] = acc;
         }
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a,  (size_t)K * M);
     hipMalloc(&d_b,  (size_t)K * N);
     hipMalloc(&d_c,  MN * sizeof(float));
     hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));
     hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa_ln, (size_t)k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)k_iters * tiles_N * 512 * sizeof(uint32_t));
     hipMemcpy(d_a,  a_q_km.data(),  (size_t)K * M, hipMemcpyHostToDevice);
     hipMemcpy(d_b,  b_q_kn.data(),  (size_t)K * N, hipMemcpyHostToDevice);
     hipMemcpy(d_sa, sa_iter.data(),  (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemcpy(d_sb, sb_iter.data(),  (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemset(d_c, 0, MN * sizeof(float));
+    launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln, k_iters * tiles_M);
+    launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln, k_iters * tiles_N);
+    hipDeviceSynchronize();
 
     gl<fp8e4m3, 1, 1, K, M> A_gl(d_a, nullptr, nullptr, nullptr, nullptr);
     gl<fp8e4m3, 1, 1, K, N> B_gl(d_b, nullptr, nullptr, nullptr, nullptr);
     gl<float,   1, 1, M, N> C_gl(d_c, nullptr, nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa), k_iters * (M / BLOCK_ROW), nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb), k_iters * (N / BLOCK_COL), nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa_ln), k_iters * tiles_M, nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb_ln), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
     mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A_gl, B_gl, C_gl, SA_gl, SB_gl);
     hipDeviceSynchronize();
 
@@ -488,7 +555,7 @@ bool run_correctness() {
     for (size_t i = 0; i < MN; i++)
         if (std::abs(c_gpu[i] - c_ref[i]) > atol) fail_count++;
 
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     printf("  atol (0.1%%): %.2e -> %d / %zu failures -> %s\n",
            atol, fail_count, MN, fail_count == 0 ? "PASS" : "FAIL");

--- a/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_TN.cu
+++ b/kernels/cdna4/gemm/mxfp8/MXFP8_8wave/8_wave_TN.cu
@@ -34,6 +34,41 @@ constexpr int REG_N      = BLOCK_COL / WARPS_COL / 2;
 
 using G = kittens::group<NUM_WARPS>;
 
+using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
+
+// Reads the pre-packed lane-native scale for group lg on this lane (single LDS load, zero ALU).
+__device__ __forceinline__ fp8e8m0_4 lane_rd(const ST_Scale &s, int lg) {
+    return reinterpret_cast<const uint32_t *>(s.data)[lg * 64 + laneid()];
+}
+
+// Repacks the iteration-major scale buffer into the lane-native layout the kernel reads:
+// one fp8e8m0_4 per (group, lane), computed once via the same pack_scales the loop used to run.
+// One block per 256-row tile; A uses STEP=64,NG=4, B uses STEP=32,NG=8.
+template<int STEP, int NG>
+__global__ void pack_scales_lane_kernel(const uint32_t *__restrict__ packed,
+                                        uint32_t *__restrict__ ln, int num_tiles) {
+    constexpr int TILE_WORDS = 256;
+    constexpr int PAD_WORDS  = (NG - 1) * STEP + 64;  // covers max OOB pack_scales read
+    __shared__ uint32_t tile[PAD_WORDS];
+
+    int t = blockIdx.x;
+    if (t >= num_tiles) return;
+    int lane = threadIdx.x % 64;
+    int grp  = threadIdx.x / 64;
+
+    for (int i = threadIdx.x; i < PAD_WORDS; i += blockDim.x)
+        tile[i] = (i < TILE_WORDS) ? packed[(size_t)t * TILE_WORDS + i] : 0u;
+    __syncthreads();
+
+    fp8e8m0_4 out = pack_scales((const fp8e8m0 *)tile, grp * STEP);
+    ln[((size_t)t * NG + grp) * 64 + lane] = out;
+}
+
+template<int STEP, int NG>
+static void launch_pack_scales_lane(const uint32_t *packed, uint32_t *ln, int num_tiles) {
+    pack_scales_lane_kernel<STEP, NG><<<num_tiles, NG * 64>>>(packed, ln, num_tiles);
+}
+
 template <int M, int N, int K>
 __global__ __launch_bounds__(512, 2)
 void mxfp8_gemm_kernel(
@@ -47,14 +82,14 @@ void mxfp8_gemm_kernel(
 
     using ST_A     = st_fp8e4m3<HALF_ROW, BLOCK_K, st_16x128_s>;
     using ST_B     = st_fp8e4m3<HALF_COL, BLOCK_K, st_16x128_s>;
-    using ST_Scale = st<fp8e8m0, 16, 64, st_16x64_s>;
     using RT_A     = rt_fp8e4m3<REG_M, BLOCK_K>;
     using RT_B     = rt_fp8e4m3<REG_N, BLOCK_K>;
     using RT_C     = rt_fl<REG_M, REG_N, col_l, rt_16x16_s>;
 
     __shared__ ST_A As[2][2];
     __shared__ ST_B Bs[2][2];
-    __shared__ ST_Scale scale_A_smem[2], scale_B_smem[2];
+    // B needs 8 scale groups = 2 tiles: scale_B_lo holds groups 0-3, scale_B_hi groups 4-7.
+    __shared__ ST_Scale scale_A_smem[2], scale_B_lo[2], scale_B_hi[2];
 
     RT_A a;
     RT_B b0, b1;
@@ -105,11 +140,6 @@ void mxfp8_gemm_kernel(
     uint32_t b_lds_10 = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&Bs[1][0].data[0]) + wid * elem_per_warp * sizeof(T)));
     uint32_t b_lds_11 = __builtin_amdgcn_readfirstlane(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&Bs[1][1].data[0]) + wid * elem_per_warp * sizeof(T)));
 
-    int a_row_h0 = warp_m * REG_M;
-    int a_row_h1 = HALF_ROW + warp_m * REG_M;
-    int b_row_h0 = warp_n * REG_N;
-    int b_row_h1 = HALF_COL + warp_n * REG_N;
-
     int tic = 0, toc = 1;
     int tic_scales = 0, toc_scales = 1;
 
@@ -131,8 +161,9 @@ void mxfp8_gemm_kernel(
     asm volatile("s_waitcnt vmcnt(6)");
     __builtin_amdgcn_s_barrier();
 
-    G::load(scale_A_smem[0], scale_A_gl, {0 * tiles_M + block_row, 0, 0, 0});
-    G::load(scale_B_smem[0], scale_B_gl, {0 * tiles_N + block_col, 0, 0, 0});
+    G::load(scale_A_smem[0], scale_A_gl, {block_row, 0, 0, 0});
+    G::load(scale_B_lo[0],   scale_B_gl, {2 * block_col,     0, 0, 0});
+    G::load(scale_B_hi[0],   scale_B_gl, {2 * block_col + 1, 0, 0, 0});
     asm volatile("s_waitcnt vmcnt(0)");
     asm volatile("s_waitcnt lgkmcnt(0)");
     __builtin_amdgcn_s_barrier();
@@ -141,7 +172,8 @@ void mxfp8_gemm_kernel(
     for (int k = 0; k < k_iters - 2; k++, tic ^= 1, toc ^= 1, tic_scales ^= 1, toc_scales ^= 1) {
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
         auto bs0 = subtile_inplace<REG_N, BLOCK_K>(Bs[tic][0], {warp_n, 0});
         load(b0, bs0);
@@ -151,10 +183,10 @@ void mxfp8_gemm_kernel(
         asm volatile("s_waitcnt lgkmcnt(8)");
         __builtin_amdgcn_s_barrier();
 
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
         __builtin_amdgcn_s_setprio(2);
         mma_ABt_scaled(cA, a, b0, cA, &sa_h0, &sb_h0);
         __builtin_amdgcn_s_setprio(0);
@@ -198,15 +230,16 @@ void mxfp8_gemm_kernel(
         int k = k_iters - 2;
         if (k + 1 < k_iters) {
             G::load(scale_A_smem[toc_scales], scale_A_gl, {(k + 1) * tiles_M + block_row, 0, 0, 0});
-            G::load(scale_B_smem[toc_scales], scale_B_gl, {(k + 1) * tiles_N + block_col, 0, 0, 0});
+            G::load(scale_B_lo[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col),     0, 0, 0});
+            G::load(scale_B_hi[toc_scales],   scale_B_gl, {2 * ((k + 1) * tiles_N + block_col) + 1, 0, 0, 0});
         }
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         auto bs0 = subtile_inplace<REG_N, BLOCK_K>(Bs[tic][0], {warp_n, 0});
         load(b0, bs0);
@@ -262,10 +295,10 @@ void mxfp8_gemm_kernel(
         asm volatile("s_waitcnt vmcnt(0)");
         asm volatile("s_waitcnt lgkmcnt(0)");
         __builtin_amdgcn_s_barrier();
-        fp8e8m0_4 sa_h0 = pack_scales(scale_A_smem[tic_scales].data, a_row_h0);
-        fp8e8m0_4 sa_h1 = pack_scales(scale_A_smem[tic_scales].data, a_row_h1);
-        fp8e8m0_4 sb_h0 = pack_scales(scale_B_smem[tic_scales].data, b_row_h0);
-        fp8e8m0_4 sb_h1 = pack_scales(scale_B_smem[tic_scales].data, b_row_h1);
+        fp8e8m0_4 sa_h0 = lane_rd(scale_A_smem[tic_scales], warp_m);
+        fp8e8m0_4 sa_h1 = lane_rd(scale_A_smem[tic_scales], 2 + warp_m);
+        fp8e8m0_4 sb_h0 = lane_rd(scale_B_lo[tic_scales], warp_n);
+        fp8e8m0_4 sb_h1 = lane_rd(scale_B_hi[tic_scales], warp_n);
 
         auto as0 = subtile_inplace<REG_M, BLOCK_K>(As[tic][0], {warp_m, 0});
         load(a, as0);
@@ -382,32 +415,39 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     std::vector<uint8_t> sa_raw, sb_raw;
     std::vector<uint32_t> sa_iter, sb_iter;
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a, (size_t)ROTATING_BUFFER_COUNT * M * K);
     hipMalloc(&d_b, (size_t)ROTATING_BUFFER_COUNT * N * K);
     hipMalloc(&d_c, (size_t)M * N * sizeof(float));
-    hipMalloc(&d_sa, (size_t)ROTATING_BUFFER_COUNT * k_iters * M * sizeof(uint32_t));
-    hipMalloc(&d_sb, (size_t)ROTATING_BUFFER_COUNT * k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));  // iteration-major staging
+    hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    // Lane-native buffers (A: 256 words/tile, B: 512 words/tile), one per rotating buffer.
+    hipMalloc(&d_sa_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)ROTATING_BUFFER_COUNT * k_iters * tiles_N * 512 * sizeof(uint32_t));
     HipCheckError();
 
     for (int buf = 0; buf < ROTATING_BUFFER_COUNT; buf++) {
         random_init_mxfp8<M, N, K>(a_f, b_f, a_q, b_q, sa_raw, sb_raw, sa_iter, sb_iter, 42 + buf);
         hipMemcpy(d_a  + (size_t)buf * M * K, a_q.data(), (size_t)M * K, hipMemcpyHostToDevice);
         hipMemcpy(d_b  + (size_t)buf * N * K, b_q.data(), (size_t)N * K, hipMemcpyHostToDevice);
-        hipMemcpy(d_sa + (size_t)buf * k_iters * M, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
-        hipMemcpy(d_sb + (size_t)buf * k_iters * N, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sa, sa_iter.data(), (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
+        hipMemcpy(d_sb, sb_iter.data(), (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
+        launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln + (size_t)buf * k_iters * tiles_M * 256, k_iters * tiles_M);
+        launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln + (size_t)buf * k_iters * tiles_N * 512, k_iters * tiles_N);
     }
+    hipDeviceSynchronize();
     HipCheckError();
 
-    constexpr int tiles_M = M / BLOCK_ROW;
-    constexpr int tiles_N = N / BLOCK_COL;
     for (int i = 0; i < warmup_iters; i++) {
         int buf = i % ROTATING_BUFFER_COUNT;
         gl<fp8e4m3, 1, 1, M, K> A(d_a + (size_t)buf * M * K, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, N, K> B(d_b + (size_t)buf * N * K, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipDeviceSynchronize();
     }
@@ -420,8 +460,8 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
         gl<fp8e4m3, 1, 1, M, K> A(d_a + (size_t)buf * M * K, nullptr, nullptr, nullptr, nullptr);
         gl<fp8e4m3, 1, 1, N, K> B(d_b + (size_t)buf * N * K, nullptr, nullptr, nullptr, nullptr);
         gl<float,   1, 1, M, N> C(d_c, nullptr, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa + (size_t)buf * k_iters * M), k_iters * tiles_M, nullptr, nullptr, nullptr);
-        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb + (size_t)buf * k_iters * N), k_iters * tiles_N, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SA(reinterpret_cast<fp8e8m0 *>(d_sa_ln + (size_t)buf * k_iters * tiles_M * 256), k_iters * tiles_M, nullptr, nullptr, nullptr);
+        gl<fp8e8m0, -1, 1, 16, 64> SB(reinterpret_cast<fp8e8m0 *>(d_sb_ln + (size_t)buf * k_iters * tiles_N * 512), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
         hipEventRecord(t0);
         mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A, B, C, SA, SB);
         hipEventRecord(t1);
@@ -435,7 +475,7 @@ TimingResult run_benchmark(int warmup_iters, int timing_iters) {
     double ops = 2.0 * M * N * K;
 
     hipEventDestroy(t0); hipEventDestroy(t1);
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     return { best, avg, ops / (best * 1e-3) / 1e12, ops / (avg * 1e-3) / 1e12, timing_iters };
 }
@@ -471,23 +511,30 @@ bool run_correctness() {
             c_ref[(size_t)i * N + j] = acc;
         }
 
-    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb;
+    constexpr int tiles_M = M / BLOCK_ROW;
+    constexpr int tiles_N = N / BLOCK_COL;
+    fp8e4m3 *d_a, *d_b; float *d_c; uint32_t *d_sa, *d_sb, *d_sa_ln, *d_sb_ln;
     hipMalloc(&d_a,  (size_t)M * K);
     hipMalloc(&d_b,  (size_t)N * K);
     hipMalloc(&d_c,  MN * sizeof(float));
     hipMalloc(&d_sa, (size_t)k_iters * M * sizeof(uint32_t));
     hipMalloc(&d_sb, (size_t)k_iters * N * sizeof(uint32_t));
+    hipMalloc(&d_sa_ln, (size_t)k_iters * tiles_M * 256 * sizeof(uint32_t));
+    hipMalloc(&d_sb_ln, (size_t)k_iters * tiles_N * 512 * sizeof(uint32_t));
     hipMemcpy(d_a,  a_q.data(),     (size_t)M * K, hipMemcpyHostToDevice);
     hipMemcpy(d_b,  b_q.data(),     (size_t)N * K, hipMemcpyHostToDevice);
     hipMemcpy(d_sa, sa_iter.data(),  (size_t)k_iters * M * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemcpy(d_sb, sb_iter.data(),  (size_t)k_iters * N * sizeof(uint32_t), hipMemcpyHostToDevice);
     hipMemset(d_c, 0, MN * sizeof(float));
+    launch_pack_scales_lane<64, 4>(d_sa, d_sa_ln, k_iters * tiles_M);
+    launch_pack_scales_lane<32, 8>(d_sb, d_sb_ln, k_iters * tiles_N);
+    hipDeviceSynchronize();
 
     gl<fp8e4m3, 1, 1, M, K> A_gl(d_a, nullptr, nullptr, nullptr, nullptr);
     gl<fp8e4m3, 1, 1, N, K> B_gl(d_b, nullptr, nullptr, nullptr, nullptr);
     gl<float,   1, 1, M, N> C_gl(d_c, nullptr, nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa), k_iters * (M / BLOCK_ROW), nullptr, nullptr, nullptr);
-    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb), k_iters * (N / BLOCK_COL), nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SA_gl(reinterpret_cast<fp8e8m0 *>(d_sa_ln), k_iters * tiles_M, nullptr, nullptr, nullptr);
+    gl<fp8e8m0, -1, 1, 16, 64> SB_gl(reinterpret_cast<fp8e8m0 *>(d_sb_ln), 2 * k_iters * tiles_N, nullptr, nullptr, nullptr);
     mxfp8_gemm_kernel<M, N, K><<<grid, 512>>>(A_gl, B_gl, C_gl, SA_gl, SB_gl);
     hipDeviceSynchronize();
 
@@ -501,7 +548,7 @@ bool run_correctness() {
     for (size_t i = 0; i < MN; i++)
         if (std::abs(c_gpu[i] - c_ref[i]) > atol) fail_count++;
 
-    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb);
+    hipFree(d_a); hipFree(d_b); hipFree(d_c); hipFree(d_sa); hipFree(d_sb); hipFree(d_sa_ln); hipFree(d_sb_ln);
 
     printf("  atol (0.1%%): %.2e -> %d / %zu failures -> %s\n",
            atol, fail_count, MN, fail_count == 0 ? "PASS" : "FAIL");


### PR DESCRIPTION
Moves the per-iteration kittens scale perm/shuffle out of the GEMM kernel and fuses into `pack_scales_kernel`, so every scale read becomes a single LDS load. 
NN and NT additionally switch their data loads to the SRD buffer-load path already used by TN

## Average speedup by layout (E4M3 in, BF16 out)

| Layout | Pass  | Avg speedup | Median | Range |
|--------|-------|-------------|--------|-------|
| TN     | fprop | **+5.6%**   | +5.9%  | +0.9% -- +9.9%
| NN     | dgrad | **+8.6%**   | +8.3%  | +6.2% -- +11.1%
| NT     | wgrad | **+8.0%**   | +8.0%  | +6.0% -- +9.6%

<details>
<summary><b>TN (fprop) — per-shape speedup</b></summary>

| M | N | K | perm TFLOPS | lane TFLOPS | speedup |
|---|---|---|---|---|---|
| 4096 | 4096 | 4096 | 2051 | 2138 | +4.2% |
| 4096 | 4096 | 11008 | 2350 | 2583 | +9.9% |
| 4096 | 4096 | 14336 | 2401 | 2638 | +9.9% |
| 4096 | 6144 | 4096 | 1733 | 1815 | +4.7% |
| 4096 | 8192 | 8192 | 2309 | 2528 | +9.5% |
| 4096 | 8192 | 28672 | 2594 | 2804 | +8.1% |
| 4096 | 10240 | 8192 | 2081 | 2210 | +6.2% |
| 4096 | 12288 | 4096 | 2059 | 2181 | +5.9% |
| 4096 | 22016 | 4096 | 1959 | 2032 | +3.7% |
| 4096 | 28672 | 4096 | 2127 | 2196 | +3.2% |
| 4096 | 57344 | 8192 | 2401 | 2569 | +7.0% |
| 8192 | 3584 | 3584 | 1901 | 2014 | +6.0% |
| 8192 | 3584 | 18944 | 2324 | 2525 | +8.7% |
| 8192 | 4096 | 4096 | 2111 | 2163 | +2.5% |
| 8192 | 4096 | 11008 | 2428 | 2623 | +8.1% |
| 8192 | 4096 | 14336 | 2502 | 2679 | +7.1% |
| 8192 | 4608 | 3584 | 1714 | 1788 | +4.3% |
| 8192 | 6144 | 4096 | 2086 | 2186 | +4.8% |
| 8192 | 8192 | 8192 | 2404 | 2567 | +6.8% |
| 8192 | 8192 | 28672 | 2603 | 2823 | +8.4% |
| 8192 | 8192 | 29568 | 2619 | 2824 | +7.8% |
| 8192 | 10240 | 8192 | 2402 | 2539 | +5.7% |
| 8192 | 12288 | 4096 | 2183 | 2305 | +5.6% |
| 8192 | 16384 | 16384 | 2572 | 2744 | +6.6% |
| 8192 | 16384 | 53248 | 2674 | 2880 | +7.7% |
| 8192 | 18432 | 16384 | 2583 | 2762 | +6.9% |
| 8192 | 22016 | 4096 | 2156 | 2247 | +4.2% |
| 8192 | 28672 | 4096 | 2184 | 2246 | +2.8% |
| 8192 | 37888 | 3584 | 2111 | 2153 | +2.0% |
| 8192 | 57344 | 8192 | 2456 | 2578 | +4.9% |
| 8192 | 59136 | 8192 | 2444 | 2575 | +5.4% |
| 8192 | 106496 | 16384 | 2592 | 2763 | +6.6% |
| 16384 | 3584 | 3584 | 1812 | 1919 | +5.9% |
| 16384 | 3584 | 18944 | 2304 | 2466 | +7.0% |
| 16384 | 4096 | 4096 | 2149 | 2231 | +3.8% |
| 16384 | 4096 | 11008 | 2473 | 2650 | +7.2% |
| 16384 | 4096 | 14336 | 2535 | 2721 | +7.3% |
| 16384 | 4608 | 3584 | 1982 | 2051 | +3.5% |
| 16384 | 6144 | 4096 | 2210 | 2294 | +3.8% |
| 16384 | 8192 | 8192 | 2433 | 2591 | +6.5% |
| 16384 | 8192 | 28672 | 2647 | 2844 | +7.4% |
| 16384 | 8192 | 29568 | 2647 | 2839 | +7.3% |
| 16384 | 10240 | 8192 | 2450 | 2560 | +4.5% |
| 16384 | 12288 | 4096 | 2217 | 2345 | +5.8% |
| 16384 | 16384 | 16384 | 2583 | 2769 | +7.2% |
| 16384 | 16384 | 53248 | 2689 | 2866 | +6.6% |
| 16384 | 18432 | 16384 | 2584 | 2743 | +6.2% |
| 16384 | 22016 | 4096 | 2196 | 2273 | +3.5% |
| 16384 | 28672 | 4096 | 2219 | 2282 | +2.8% |
| 16384 | 37888 | 3584 | 2150 | 2183 | +1.5% |
| 16384 | 57344 | 8192 | 2452 | 2576 | +5.0% |
| 16384 | 59136 | 8192 | 2449 | 2573 | +5.0% |
| 16384 | 106496 | 16384 | 2600 | 2760 | +6.2% |
| 32768 | 3584 | 3584 | 2092 | 2189 | +4.6% |
| 32768 | 3584 | 18944 | 2596 | 2779 | +7.0% |
| 32768 | 4096 | 4096 | 2205 | 2252 | +2.1% |
| 32768 | 4096 | 14336 | 2558 | 2723 | +6.5% |
| 32768 | 4608 | 3584 | 2138 | 2216 | +3.6% |
| 32768 | 6144 | 4096 | 2227 | 2306 | +3.5% |
| 32768 | 8192 | 8192 | 2486 | 2534 | +1.9% |
| 32768 | 8192 | 29568 | 2662 | 2838 | +6.6% |
| 32768 | 10240 | 8192 | 2454 | 2581 | +5.2% |
| 32768 | 16384 | 16384 | 2591 | 2758 | +6.4% |
| 32768 | 16384 | 53248 | 2662 | 2848 | +7.0% |
| 32768 | 18432 | 16384 | 2593 | 2748 | +6.0% |
| 32768 | 28672 | 4096 | 2253 | 2311 | +2.6% |
| 32768 | 37888 | 3584 | 2187 | 2206 | +0.9% |
| 32768 | 59136 | 8192 | 2453 | 2572 | +4.9% |
| 32768 | 106496 | 16384 | 2596 | 2754 | +6.1% |

</details>

<details>
<summary><b>NN (dgrad) — per-shape speedup</b></summary>

| M | N | K | perm TFLOPS | SRD+lane TFLOPS | speedup |
|---|---|---|---|---|---|
| 4096 | 4096 | 4096 | 1867 | 2024 | +8.4% |
| 4096 | 4096 | 6144 | 2048 | 2210 | +7.9% |
| 4096 | 4096 | 12288 | 2247 | 2425 | +8.0% |
| 4096 | 4096 | 22016 | 2354 | 2565 | +8.9% |
| 4096 | 4096 | 28672 | 2385 | 2598 | +8.9% |
| 4096 | 8192 | 8192 | 2203 | 2380 | +8.0% |
| 4096 | 8192 | 10240 | 2264 | 2432 | +7.4% |
| 4096 | 8192 | 57344 | 2446 | 2683 | +9.7% |
| 4096 | 11008 | 4096 | 1810 | 1961 | +8.3% |
| 4096 | 14336 | 4096 | 1787 | 1930 | +8.0% |
| 4096 | 28672 | 8192 | 2212 | 2396 | +8.4% |
| 8192 | 3584 | 3584 | 1735 | 1888 | +8.8% |
| 8192 | 3584 | 4608 | 1827 | 1977 | +8.2% |
| 8192 | 3584 | 37888 | 2219 | 2433 | +9.6% |
| 8192 | 4096 | 4096 | 1961 | 2113 | +7.7% |
| 8192 | 4096 | 6144 | 2118 | 2270 | +7.2% |
| 8192 | 4096 | 12288 | 2292 | 2472 | +7.9% |
| 8192 | 4096 | 22016 | 2385 | 2592 | +8.7% |
| 8192 | 4096 | 28672 | 2406 | 2631 | +9.4% |
| 8192 | 8192 | 8192 | 2231 | 2415 | +8.3% |
| 8192 | 8192 | 10240 | 2284 | 2468 | +8.1% |
| 8192 | 8192 | 57344 | 2442 | 2680 | +9.8% |
| 8192 | 8192 | 59136 | 2449 | 2685 | +9.7% |
| 8192 | 11008 | 4096 | 1820 | 1932 | +6.2% |
| 8192 | 14336 | 4096 | 2006 | 2164 | +7.8% |
| 8192 | 16384 | 16384 | 2370 | 2578 | +8.8% |
| 8192 | 16384 | 18432 | 2385 | 2594 | +8.8% |
| 8192 | 16384 | 106496 | 2408 | 2656 | +10.3% |
| 8192 | 18944 | 3584 | 1850 | 1994 | +7.8% |
| 8192 | 28672 | 8192 | 2246 | 2422 | +7.9% |
| 8192 | 29568 | 8192 | 2186 | 2363 | +8.1% |
| 8192 | 53248 | 16384 | 2373 | 2584 | +8.9% |
| 16384 | 3584 | 3584 | 1732 | 1882 | +8.7% |
| 16384 | 3584 | 4608 | 1826 | 1943 | +6.4% |
| 16384 | 3584 | 37888 | 2213 | 2421 | +9.4% |
| 16384 | 4096 | 4096 | 1999 | 2144 | +7.3% |
| 16384 | 4096 | 6144 | 2153 | 2313 | +7.4% |
| 16384 | 4096 | 12288 | 2324 | 2500 | +7.6% |
| 16384 | 4096 | 22016 | 2398 | 2612 | +8.9% |
| 16384 | 4096 | 28672 | 2420 | 2648 | +9.4% |
| 16384 | 8192 | 8192 | 2261 | 2435 | +7.7% |
| 16384 | 8192 | 10240 | 2310 | 2496 | +8.1% |
| 16384 | 8192 | 57344 | 2408 | 2670 | +10.9% |
| 16384 | 8192 | 59136 | 2402 | 2670 | +11.1% |
| 16384 | 11008 | 4096 | 2012 | 2172 | +8.0% |
| 16384 | 14336 | 4096 | 2051 | 2214 | +8.0% |
| 16384 | 16384 | 16384 | 2376 | 2583 | +8.7% |
| 16384 | 16384 | 18432 | 2390 | 2585 | +8.1% |
| 16384 | 16384 | 106496 | 2366 | 2626 | +11.0% |
| 16384 | 18944 | 3584 | 1957 | 2116 | +8.2% |
| 16384 | 28672 | 8192 | 2251 | 2440 | +8.4% |
| 16384 | 29568 | 8192 | 2246 | 2428 | +8.1% |
| 16384 | 53248 | 16384 | 2358 | 2574 | +9.2% |
| 32768 | 3584 | 3584 | 1938 | 2096 | +8.1% |
| 32768 | 3584 | 4608 | 2049 | 2216 | +8.1% |
| 32768 | 3584 | 37888 | 2388 | 2648 | +10.9% |
| 32768 | 4096 | 4096 | 2027 | 2184 | +7.7% |
| 32768 | 4096 | 6144 | 2171 | 2343 | +7.9% |
| 32768 | 4096 | 28672 | 2404 | 2640 | +9.8% |
| 32768 | 8192 | 8192 | 2270 | 2463 | +8.5% |
| 32768 | 8192 | 10240 | 2313 | 2503 | +8.2% |
| 32768 | 8192 | 59136 | 2410 | 2634 | +9.3% |
| 32768 | 14336 | 4096 | 2064 | 2245 | +8.8% |
| 32768 | 16384 | 16384 | 2360 | 2578 | +9.2% |
| 32768 | 16384 | 18432 | 2366 | 2593 | +9.6% |
| 32768 | 16384 | 106496 | 2329 | 2566 | +10.2% |
| 32768 | 18944 | 3584 | 2011 | 2178 | +8.3% |
| 32768 | 29568 | 8192 | 2243 | 2420 | +7.9% |
| 32768 | 53248 | 16384 | 2338 | 2575 | +10.2% |

</details>

<details>
<summary><b>NT (wgrad) — per-shape speedup</b></summary>

| M | N | K | perm TFLOPS | SRD+lane TFLOPS | speedup |
|---|---|---|---|---|---|
| 3584 | 3584 | 8192 | 1807 | 1921 | +6.3% |
| 3584 | 3584 | 16384 | 1985 | 2121 | +6.8% |
| 3584 | 3584 | 32768 | 2054 | 2195 | +6.9% |
| 3584 | 18944 | 8192 | 1826 | 1968 | +7.8% |
| 3584 | 18944 | 16384 | 1940 | 2090 | +7.8% |
| 3584 | 18944 | 32768 | 1986 | 2154 | +8.4% |
| 4096 | 4096 | 4096 | 1851 | 1966 | +6.2% |
| 4096 | 4096 | 8192 | 2096 | 2222 | +6.0% |
| 4096 | 4096 | 16384 | 2245 | 2407 | +7.2% |
| 4096 | 4096 | 32768 | 2321 | 2513 | +8.3% |
| 4096 | 11008 | 4096 | 1769 | 1917 | +8.3% |
| 4096 | 11008 | 8192 | 1982 | 2139 | +7.9% |
| 4096 | 11008 | 16384 | 2105 | 2275 | +8.1% |
| 4096 | 14336 | 4096 | 1751 | 1884 | +7.6% |
| 4096 | 14336 | 8192 | 1954 | 2109 | +7.9% |
| 4096 | 14336 | 16384 | 2069 | 2233 | +7.9% |
| 4096 | 14336 | 32768 | 2127 | 2292 | +7.7% |
| 4608 | 3584 | 8192 | 2046 | 2184 | +6.8% |
| 4608 | 3584 | 16384 | 2197 | 2358 | +7.3% |
| 4608 | 3584 | 32768 | 2281 | 2462 | +7.9% |
| 6144 | 4096 | 4096 | 1503 | 1627 | +8.3% |
| 6144 | 4096 | 8192 | 1700 | 1835 | +7.9% |
| 6144 | 4096 | 16384 | 1819 | 1967 | +8.1% |
| 6144 | 4096 | 32768 | 1888 | 2043 | +8.2% |
| 8192 | 8192 | 4096 | 1964 | 2112 | +7.5% |
| 8192 | 8192 | 8192 | 2180 | 2345 | +7.6% |
| 8192 | 8192 | 16384 | 2292 | 2473 | +7.9% |
| 8192 | 8192 | 32768 | 2348 | 2537 | +8.0% |
| 8192 | 28672 | 4096 | 1962 | 2123 | +8.2% |
| 8192 | 28672 | 8192 | 2178 | 2345 | +7.7% |
| 8192 | 28672 | 16384 | 2293 | 2472 | +7.8% |
| 8192 | 29568 | 8192 | 2116 | 2286 | +8.1% |
| 8192 | 29568 | 16384 | 2226 | 2400 | +7.8% |
| 8192 | 29568 | 32768 | 2253 | 2443 | +8.4% |
| 10240 | 8192 | 4096 | 1934 | 2081 | +7.6% |
| 10240 | 8192 | 8192 | 2159 | 2318 | +7.4% |
| 10240 | 8192 | 16384 | 2288 | 2466 | +7.8% |
| 10240 | 8192 | 32768 | 2335 | 2538 | +8.7% |
| 12288 | 4096 | 4096 | 1904 | 2036 | +6.9% |
| 12288 | 4096 | 8192 | 2135 | 2289 | +7.2% |
| 12288 | 4096 | 16384 | 2278 | 2449 | +7.5% |
| 16384 | 16384 | 8192 | 2194 | 2369 | +8.0% |
| 16384 | 16384 | 16384 | 2286 | 2477 | +8.4% |
| 16384 | 16384 | 32768 | 2322 | 2518 | +8.4% |
| 16384 | 53248 | 8192 | 2178 | 2363 | +8.5% |
| 16384 | 53248 | 16384 | 2269 | 2448 | +7.9% |
| 16384 | 53248 | 32768 | 2286 | 2491 | +9.0% |
| 18432 | 16384 | 8192 | 2165 | 2357 | +8.9% |
| 18432 | 16384 | 16384 | 2268 | 2465 | +8.7% |
| 18432 | 16384 | 32768 | 2309 | 2490 | +7.9% |
| 22016 | 4096 | 4096 | 1778 | 1925 | +8.3% |
| 22016 | 4096 | 8192 | 1979 | 2151 | +8.7% |
| 22016 | 4096 | 16384 | 2099 | 2281 | +8.7% |
| 28672 | 4096 | 4096 | 1947 | 2095 | +7.6% |
| 28672 | 4096 | 8192 | 2161 | 2333 | +8.0% |
| 28672 | 4096 | 16384 | 2274 | 2476 | +8.9% |
| 28672 | 4096 | 32768 | 2339 | 2524 | +7.9% |
| 37888 | 3584 | 8192 | 1996 | 2181 | +9.3% |
| 37888 | 3584 | 16384 | 2101 | 2289 | +9.0% |
| 37888 | 3584 | 32768 | 2091 | 2267 | +8.4% |
| 57344 | 8192 | 4096 | 1993 | 2170 | +8.9% |
| 57344 | 8192 | 8192 | 2184 | 2379 | +8.9% |
| 57344 | 8192 | 16384 | 2274 | 2484 | +9.2% |
| 59136 | 8192 | 8192 | 2170 | 2358 | +8.7% |
| 59136 | 8192 | 16384 | 2262 | 2464 | +8.9% |
| 59136 | 8192 | 32768 | 2286 | 2476 | +8.3% |
| 106496 | 16384 | 8192 | 2168 | 2363 | +9.0% |
| 106496 | 16384 | 16384 | 2248 | 2430 | +8.1% |
| 106496 | 16384 | 32768 | 2246 | 2460 | +9.6% |

</details>
