### PR TITLE
GFX1250 Ladder Fixes & Cleanup

### DIFF
--- a/include/udna1/types/global/gl.cuh
+++ b/include/udna1/types/global/gl.cuh
@@ -12,17 +12,6 @@
 
 namespace kittens {
 
-/* ----------   Associative dictionary for global layouts  ---------- */
-
-namespace detail {
-template<typename... Args>
-struct descriptor_dict {
-    __host__ descriptor_dict() {}
-    template<typename T> __host__ descriptor_dict(T _, int b, int d, int r, int c) {}
-    __host__ __device__ descriptor_dict(const descriptor_dict &other) {}
-};
-}
-
 /* ----------  Global layout descriptor  ---------- */
 
 namespace ducks {
@@ -32,13 +21,10 @@ struct identifier {};
 }
 
 template<typename _T, int b, int d, int r, int c,
-         ducks::gl_layout::all _Layout = ducks::gl_layout::row_major, typename... TMA_Types>
+         ducks::gl_layout::all _Layout = ducks::gl_layout::row_major>
 struct gl {
     using identifier = ducks::gl::identifier;
 
-    /* Layout sits BEFORE the TMA pack because a variadic pack must come last. That is safe
-     * here: no source in this tree passes TMA types to `gl` (the only two forms in use are
-     * `gl<T,-1,-1,-1,-1>`), so no existing declaration binds a TMA type to this slot. */
     using layout = _Layout; ///< Memory layout of the descriptor.
 
     using T     = base_types::packing<_T>::unpacked_type;
@@ -63,18 +49,14 @@ struct gl {
     template <int C=__c__> __device__ __host__ static constexpr std::enable_if_t<(C > 0), int> cols() { return C; }
     template <int C=__c__> __device__ __host__ std::enable_if_t<(C == -1), int> cols() const { return cols_internal; }
 
-    detail::descriptor_dict<TMA_Types...> tma_descs;
-
     __host__ inline gl(T *_data,
                         ducks::gl::make_arg_t<b> _batch,
                         ducks::gl::make_arg_t<d> _depth,
                         ducks::gl::make_arg_t<r> _rows,
                         ducks::gl::make_arg_t<c> _cols) :
-            raw_ptr(_data), batch_internal(_batch), depth_internal(_depth), rows_internal(_rows), cols_internal(_cols) {
-        tma_descs = detail::descriptor_dict<TMA_Types...>(raw_ptr, batch_internal, depth_internal, rows_internal, cols_internal);
-    }
+            raw_ptr(_data), batch_internal(_batch), depth_internal(_depth), rows_internal(_rows), cols_internal(_cols) {}
     __host__ __device__ inline gl(const gl &other) :
-            raw_ptr(other.raw_ptr), batch_internal(other.batch_internal), depth_internal(other.depth_internal), rows_internal(other.rows_internal), cols_internal(other.cols_internal), tma_descs(other.tma_descs) {}
+            raw_ptr(other.raw_ptr), batch_internal(other.batch_internal), depth_internal(other.depth_internal), rows_internal(other.rows_internal), cols_internal(other.cols_internal) {}
     __device__ inline T& operator[](const coord<ducks::default_type> &idx) const {
         return raw_ptr[this->idx(idx)];
     }

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/00_gemm_naive.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/00_gemm_naive.cpp
@@ -1,22 +1,25 @@
 /**
- * @file gemm_naive.cpp
- * @brief Rung 1 -- the naive baseline the rest of the ladder is built on.
+ * @file 00_gemm_naive.cpp
+ * @brief Rung 00 -- the naive baseline (no parent).
  *
  * Kernel Specification
  *   tile        64x64 macro, 32x32 per warp, 2x2 warps; BLOCK_K 32 = 1 x K_STEP 32
- *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 12 workgroups per CU, register-bound
- *   registers   68 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 32 SGPR
+ *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 10 workgroups per CU, register-bound
+ *   registers   84 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 40 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
  *   LDS         1 stage x 8.5 KB = 8.5 KB of 320 KB (2.7%)
- *   sync        per K-block: 2 barriers (full), 1 LDS drain, 1 async drain
+ *   sync        per K-block: 2 barriers (full), 2 LDS drains, 1 global-load drain
  *   intensity   32 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
  * One LDS slab and nothing overlapped. A K-block's fill cannot run under the previous block's
  * compute, and every iteration needs two barriers: one to publish the slab, one to establish
  * that every warp has finished reading it before the next fill overwrites it. The correctness
- * baseline: the smallest kernel here that computes the right answer. Uses only:
- *   - `kittens::load(st,gl,idx)`  : cooperative global -> LDS fill.
- *   - `kittens::sync::wait_async` : drain the fill before publishing the slab.
+ * baseline: the smallest kernel here that computes the right answer. The existing HK `load`
+ * performs global (GL) -> register tile (RT), then `store` performs RT -> shared (ST).
+ * Uses only:
+ *   - `kittens::load(rt,gl)`      : existing GL -> RT load.
+ *   - `kittens::store(st,rt)`     : existing RT -> ST operation.
+ *   - `kittens::sync::wait_load`  : drain GL -> RT before consuming the register tile.
  *   - `kittens::sync::wait_ds`    : drain this warp's reads before the slab is refilled.
  *   - `kittens::sync::sync`       : block-wide barrier (-1). Orders execution, not memory.
  *   - `kittens::load(rt,st,off)`  : shared -> register load (wide `ds_load_b128`).
@@ -43,8 +46,15 @@ constexpr int K_SUBBLOCKS = BLOCK_K / K_STEP;
 using namespace kittens;
 using namespace gfx1250_gemm;
 
+namespace {
+constexpr int FILL_ROWS = 16;
+using fill_rt_e = rt_e<FILL_ROWS, K_STEP>;
+using fill_st_e = st_e<FILL_ROWS, K_STEP>;
+static_assert(BLOCK_M == NUM_WARPS * FILL_ROWS && BLOCK_N == NUM_WARPS * FILL_ROWS);
+} // namespace
+
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_naive_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_00_naive_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -71,31 +81,44 @@ void gemm_naive_kernel(const gemm_globals g, int M, int N, int K)
 
     // Main loop: one K-block per iteration.
     for (int kb = 0; kb < k_blocks; ++kb) {
-        // Every thread participates: `load` spreads the tile across all NUM_THREADS lanes.
-        kittens::load<NUM_THREADS>(A_st, g.a, {0, 0, tile_m, kb}, K);
-        kittens::load<NUM_THREADS>(B_st, g.b, {0, 0, tile_n, kb}, K);
+        /* One 16x32 slice per warp. The slice reference starts at the parent tile's padded
+         * physical origin; the existing store owns every element address within that slice. */
+        fill_rt_e fill_rt;
+        fill_st_e& A_fill_st = *reinterpret_cast<fill_st_e*>(
+            &A_st.data[A_tile::idx(wid * FILL_ROWS, 0)]);
+        kittens::load(
+            fill_rt, g.a, {0, 0, tile_m * (BLOCK_M / FILL_ROWS) + wid, kb}); // GL -> RT
+        kittens::sync::wait_load<0>();
+        kittens::store(A_fill_st, fill_rt);                           // RT -> ST
 
-        kittens::sync::wait_async<0>();           // wait for data (async copy): the slab has landed
+        fill_st_e& B_fill_st = *reinterpret_cast<fill_st_e*>(
+            &B_st.data[B_tile::idx(wid * FILL_ROWS, 0)]);
+        kittens::load(
+            fill_rt, g.b, {0, 0, tile_n * (BLOCK_N / FILL_ROWS) + wid, kb}); // GL -> RT
+        kittens::sync::wait_load<0>();
+        kittens::store(B_fill_st, fill_rt);                           // RT -> ST
+
+        kittens::sync::wait_ds<0>();              // wait for data (LDS): RT -> ST writes landed
         kittens::sync::sync();                    // wait for everyone (workgroup): the slab is readable
 
         kittens::load(A_reg, A_st, warp_off_a);
         kittens::load(B_reg, B_st, warp_off_b);
+        kittens::sync::wait_ds<0>();              // wait for data (LDS): ST -> RT reads landed
         mma_ABt(C_acc, A_reg, B_reg, C_acc);
 
-        kittens::sync::wait_ds<0>();              // wait for data (LDS): our reads of the slab are done
         kittens::sync::sync();                    // wait for everyone (workgroup): safe to refill it
     }
 
     /* Epilogue: each warp converts its accumulator to bf16 straight into global C. Column-major C
      * makes a lane's run of consecutive rows unit-stride, so store WIDTH is fine; what the direct
      * store gives up is transaction SIZE -- a warp's 32 lanes span 16 columns, so the writes
-     * scatter per column. Rung 11 stages through LDS so the block's rows leave as one stream. */
+     * scatter per column. Rung 10 stages through LDS so the block's rows leave as one stream. */
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
-    const size_t mem_size = g.dynamic_shared_memory<1>();
+    const size_t mem_size = launch.dynamic_shared_memory<1>();
 
     /* The direct store writes a lane's run of consecutive rows as one sized buffer store, so the
      * run has to be aligned, which needs the leading dimension to divide it. Kept at 8 rather than
@@ -103,15 +126,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_naive: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "00_gemm_naive: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_naive");
+    gfx1250_gemm::require_k_blocks(g.K(), "00_gemm_naive");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_naive_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_00_naive_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_naive_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_00_naive_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/01_gemm_double_buf.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/01_gemm_double_buf.cpp
@@ -1,24 +1,25 @@
 /**
- * @file gemm_double_buf.cpp
- * @brief Rung 2 -- gemm_naive plus a second LDS stage.
+ * @file 01_gemm_double_buf.cpp
+ * @brief Rung 01 -- 00_gemm_naive plus a second LDS stage.
  *
  * Kernel Specification
  *   tile        64x64 macro, 32x32 per warp, 2x2 warps; BLOCK_K 32 = 1 x K_STEP 32
- *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 12 workgroups per CU, register-bound
- *   registers   67 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 29 SGPR
+ *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 10 workgroups per CU, register-bound
+ *   registers   82 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 38 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
  *   LDS         2 stages x 8.5 KB = 17 KB of 320 KB (5.3%)
- *   sync        per K-block: 1 barrier (full), 1 LDS drain, 1 async drain
+ *   sync        per K-block: 1 barrier (full), 1 LDS drain, 1 global-load drain
  *   intensity   32 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
  * Two interleaved stages in one segment rather than a single slab, so a K-block's fill runs
  * under the previous block's compute and the publish-then-drain barrier pair collapses to one
- * rendezvous. Same 64x64 tile and the same fill.
+ * rendezvous. Same 64x64 tile and the same separate GL -> RT, then RT -> ST path as rung 00.
  *
  * The fill still leads the operand reads here. Nothing else covers its global latency, so it
  * must be in flight across the reads and the matrix op below. Uses only:
- *   - `kittens::load(st,gl,idx)`  : cooperative global -> LDS fill.
- *   - `kittens::sync::wait_async` : drain the fill before the rendezvous.
+ *   - `kittens::load(rt,gl)`      : existing GL -> RT load.
+ *   - `kittens::store(st,rt)`     : existing RT -> ST operation.
+ *   - `kittens::sync::wait_load`  : drain GL -> RT before consuming the register tile.
  *   - `kittens::sync::sync`       : block-wide barrier (-1).
  *   - `kittens::sync::wait_ds`    : drain the wave's LDS reads before the handoff and before exit.
  *   - `kittens::load(rt,st,off)`  : shared -> register load (wide `ds_load_b128`).
@@ -47,13 +48,20 @@ using namespace gfx1250_gemm;
 
 static constexpr int S = 2;                    // stages in the LDS ring
 
+namespace {
+constexpr int FILL_ROWS = 16;
+using fill_rt_e = rt_e<FILL_ROWS, K_STEP>;
+using fill_st_e = st_e<FILL_ROWS, K_STEP>;
+static_assert(BLOCK_M == NUM_WARPS * FILL_ROWS && BLOCK_N == NUM_WARPS * FILL_ROWS);
+} // namespace
+
 // One ring slot, with A and B adjacent.
 struct KITTENS_DEFAULT_ALIGN ab_pair { A_tile a; B_tile b; };
 static_assert(sizeof(ab_pair) == sizeof(A_tile) + sizeof(B_tile),
               "an interleaved pair must not introduce padding");
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_double_buf_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_01_double_buf_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -74,10 +82,23 @@ void gemm_double_buf_kernel(const gemm_globals g, int M, int N, int K)
     const int warp_off_a = warp_r * WARP_M * K_STEP;
     const int warp_off_b = warp_c * WARP_N * K_STEP;
 
-    // Every thread participates: `load` spreads the tile across all NUM_THREADS lanes.
     auto issue_fill = [&](int slot, int kblock) {
-        kittens::load<NUM_THREADS>(ring[slot].a, g.a, {0, 0, tile_m, kblock}, K);
-        kittens::load<NUM_THREADS>(ring[slot].b, g.b, {0, 0, tile_n, kblock}, K);
+        fill_rt_e fill_rt;
+        fill_st_e& A_fill_st = *reinterpret_cast<fill_st_e*>(
+            &ring[slot].a.data[A_tile::idx(wid * FILL_ROWS, 0)]);
+        kittens::load(
+            fill_rt, g.a,
+            {0, 0, tile_m * (BLOCK_M / FILL_ROWS) + wid, kblock}); // GL -> RT
+        kittens::sync::wait_load<0>();
+        kittens::store(A_fill_st, fill_rt);                              // RT -> ST
+
+        fill_st_e& B_fill_st = *reinterpret_cast<fill_st_e*>(
+            &ring[slot].b.data[B_tile::idx(wid * FILL_ROWS, 0)]);
+        kittens::load(
+            fill_rt, g.b,
+            {0, 0, tile_n * (BLOCK_N / FILL_ROWS) + wid, kblock}); // GL -> RT
+        kittens::sync::wait_load<0>();
+        kittens::store(B_fill_st, fill_rt);                              // RT -> ST
     };
 
     // Prologue: fill the ring ahead of the loop.
@@ -85,7 +106,7 @@ void gemm_double_buf_kernel(const gemm_globals g, int M, int N, int K)
     for (int s = 0; s < S - 1; ++s)
         if (s < k_blocks) issue_fill(s, s);
 
-    kittens::sync::wait_async<0>();                   // wait for data (async copy): stage 0 landed
+    kittens::sync::wait_ds<0>();                      // wait for data (LDS): RT -> ST writes landed
     kittens::sync::sync();                            // wait for everyone (workgroup): stage 0 readable
 
     rt_e<WARP_M, K_STEP> A_reg;
@@ -102,23 +123,22 @@ void gemm_double_buf_kernel(const gemm_globals g, int M, int N, int K)
 
         kittens::load(A_reg, ring[cur].a, warp_off_a);
         kittens::load(B_reg, ring[cur].b, warp_off_b);
+        kittens::sync::wait_ds<0>();    // wait for data (LDS): reads and next-stage writes are done
         mma_ABt(C_acc, A_reg, B_reg, C_acc);
 
-        kittens::sync::wait_ds<0>();    // wait for data (LDS): our reads of this stage are done
-        kittens::sync::wait_async<0>(); // wait for data (async copy): the next stage's fill landed
         kittens::sync::sync();          // wait for everyone (workgroup): publish the fill, free the stage
     }
 
     // Nothing reuses the ring now; this drains the wave's outstanding LDS traffic before exit.
     kittens::sync::wait_ds<0>();     // wait for data (LDS): no read may outlive the workgroup
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
-    const size_t mem_size = g.dynamic_shared_memory<S>();
+    const size_t mem_size = launch.dynamic_shared_memory<S>();
 
     /* The direct store writes a lane's run of consecutive rows as one sized buffer store, so the
      * run has to be aligned, which needs the leading dimension to divide it. Kept at 8 rather than
@@ -126,15 +146,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_double_buf: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "01_gemm_double_buf: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_double_buf");
+    gfx1250_gemm::require_k_blocks(g.K(), "01_gemm_double_buf");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_double_buf_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_01_double_buf_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_double_buf_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_01_double_buf_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/02_gemm_async.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/02_gemm_async.cpp
@@ -1,26 +1,23 @@
 /**
- * @file gemm_256x256.cpp
- * @brief Rung 5 -- gemm_128x128 with the macro tile doubled again, to 256x256.
+ * @file 02_gemm_async.cpp
+ * @brief Rung 02 -- 01_gemm_double_buf plus the cooperative async fill.
  *
  * Kernel Specification
- *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 32 = 1 x K_STEP 32
- *   occupancy   16 warps / 512 threads / 4 waves per SIMD, one workgroup per CU
- *   registers   220 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
- *               (WARP_M*WARP_N/32), 26 SGPR
+ *   tile        64x64 macro, 32x32 per warp, 2x2 warps; BLOCK_K 32 = 1 x K_STEP 32
+ *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 10 workgroups per CU, register-bound
+ *   registers   83 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 30 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
- *   LDS         2 stages x 34 KB = 68 KB of 320 KB (21.3%)
+ *   LDS         2 stages x 8.5 KB = 17 KB of 320 KB (5.3%)
  *   sync        per K-block: 1 barrier (split), 1 LDS drain, 1 async drain
- *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
+ *   intensity   32 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * Arithmetic intensity rises from 64 to 128 FLOP per byte, and each warp's output tile goes from
- * 32x32 to 64x64, worth about 1.25x. This is the largest tile the register file allows at four
- * waves per SIMD: the accumulator alone is 128 VGPRs of the 256 a lane gets there, and the kernel
- * totals 220. Doubling the warp tile again needs 512 accumulator VGPRs, which fits only by dropping
- * to one wave per SIMD for a 1024-VGPR budget. So the ladder stops growing the tile here and starts
- * deepening it instead. Same BLOCK_K=32, 4x4 warps, two async-filled
- * stages in one LDS segment, plain split barrier, direct column-major epilogue. A stage still
- * covers exactly one matrix sub-step, so what overlaps here is the cross-K-block prefetch, one
- * stage ahead. Uses only:
+ * `global_load_async_to_lds_b128` lands operands in LDS without staging them through VGPRs, so
+ * the registers and issue slots the register-mediated copy spent go back to the K-loop and the
+ * fill no longer has to lead the operand reads. It is worth about 1.47x, one of the two largest
+ * steps on the ladder. What it costs is a second counter to reason about: the fill retires on the
+ * async counter, the operand reads on the LDS counter, and the stage handoff has to drain both.
+ * Same 64x64 tile, two interleaved stages of a padded 64x32 LDS tile in one segment, plain split
+ * barrier, direct column-major epilogue. Uses only:
  *   - `kittens::load`       : cooperative `global_load_async_to_lds_b128` fill.
  *   - `kittens::sync::wait_async` : drain the async fill.
  *   - `kittens::sync::arrive/wait`: split workgroup barrier (-1).
@@ -33,12 +30,12 @@
 
 #include "kittens.cuh"
 
-constexpr int BLOCK_M     = 256;
-constexpr int BLOCK_N     = 256;
+constexpr int BLOCK_M     = 64;
+constexpr int BLOCK_N     = 64;
 constexpr int BLOCK_K     = 32;
 constexpr int K_STEP      = 32;
-constexpr int WARPS_M     = 4;
-constexpr int WARPS_N     = 4;
+constexpr int WARPS_M     = 2;
+constexpr int WARPS_N     = 2;
 constexpr int WARP_M      = BLOCK_M / WARPS_M;
 constexpr int WARP_N      = BLOCK_N / WARPS_N;
 constexpr int NUM_WARPS   = WARPS_M * WARPS_N;
@@ -58,7 +55,7 @@ static_assert(sizeof(ab_pair) == sizeof(A_tile) + sizeof(B_tile),
               "an interleaved pair must not introduce padding");
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_256x256_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_async_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -103,6 +100,8 @@ void gemm_256x256_kernel(const gemm_globals g, int M, int N, int K)
         const int cur = kb % S, nxt = (kb + 1) % S;
 
         kittens::sched::compiler_fence();
+        // The operand reads lead the fill: an async fill carries its own latency, so
+        // reading first gets the matrix op started sooner.
         kittens::load(A_reg, ring[cur].a, warp_off_a);
         kittens::load(B_reg, ring[cur].b, warp_off_b);
 
@@ -132,7 +131,7 @@ void gemm_256x256_kernel(const gemm_globals g, int M, int N, int K)
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     // The C staging tile reuses the ring, so the request is the larger of the two, not the sum.
     const size_t load_lds  = S * sizeof(ab_pair);
@@ -144,15 +143,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_256x256: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "02_gemm_async: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_256x256");
+    gfx1250_gemm::require_k_blocks(g.K(), "02_gemm_async");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_256x256_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_async_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_256x256_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_async_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/03_gemm_128x128.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/03_gemm_128x128.cpp
@@ -1,23 +1,22 @@
 /**
- * @file gemm_async.cpp
- * @brief Rung 3 -- gemm_double_buf plus the cooperative async fill.
+ * @file 03_gemm_128x128.cpp
+ * @brief Rung 03 -- 02_gemm_async with the macro tile doubled to 128x128.
  *
  * Kernel Specification
- *   tile        64x64 macro, 32x32 per warp, 2x2 warps; BLOCK_K 32 = 1 x K_STEP 32
- *   occupancy   4 warps / 128 threads / 1 wave per SIMD; 10 workgroups per CU, register-bound
- *   registers   83 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 30 SGPR
+ *   tile        128x128 macro, 32x32 per warp, 4x4 warps; BLOCK_K 32 = 1 x K_STEP 32
+ *   occupancy   16 warps / 512 threads / 4 waves per SIMD; 2 workgroups per CU, register-bound
+ *   registers   94 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 26 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
- *   LDS         2 stages x 8.5 KB = 17 KB of 320 KB (5.3%)
+ *   LDS         2 stages x 17 KB = 34 KB of 320 KB (10.6%)
  *   sync        per K-block: 1 barrier (split), 1 LDS drain, 1 async drain
- *   intensity   32 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
+ *   intensity   64 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * `global_load_async_to_lds_b128` lands operands in LDS without staging them through VGPRs, so
- * the registers and issue slots the register-mediated copy spent go back to the K-loop and the
- * fill no longer has to lead the operand reads. It is worth about 1.6x, one of the two largest
- * steps on the ladder. What it costs is a second counter to reason about: the fill retires on the
- * async counter, the operand reads on the LDS counter, and the stage handoff has to drain both.
- * Same 64x64 tile, two interleaved stages of a padded 64x32 LDS tile in one segment, plain split
- * barrier, direct column-major epilogue. Uses only:
+ * Arithmetic intensity for a square bf16 tile is M*N/(M+N) FLOP per byte, so it rises from 32 to
+ * 64 across this step and the operand traffic per output element halves. That is worth about
+ * 1.8x, the largest step on the ladder. The warp grid has to double with the tile, 2x2 -> 4x4, to
+ * hold the warp tile at 32x32: a 2x2 grid on a 128x128 tile gives each warp four times the
+ * accumulator and spills. Same BLOCK_K=32, two async-filled stages interleaved in one LDS
+ * segment, plain split barrier, direct column-major epilogue. Uses only:
  *   - `kittens::load`       : cooperative `global_load_async_to_lds_b128` fill.
  *   - `kittens::sync::wait_async` : drain the async fill.
  *   - `kittens::sync::arrive/wait`: split workgroup barrier (-1).
@@ -30,12 +29,12 @@
 
 #include "kittens.cuh"
 
-constexpr int BLOCK_M     = 64;
-constexpr int BLOCK_N     = 64;
+constexpr int BLOCK_M     = 128;
+constexpr int BLOCK_N     = 128;
 constexpr int BLOCK_K     = 32;
 constexpr int K_STEP      = 32;
-constexpr int WARPS_M     = 2;
-constexpr int WARPS_N     = 2;
+constexpr int WARPS_M     = 4;
+constexpr int WARPS_N     = 4;
 constexpr int WARP_M      = BLOCK_M / WARPS_M;
 constexpr int WARP_N      = BLOCK_N / WARPS_N;
 constexpr int NUM_WARPS   = WARPS_M * WARPS_N;
@@ -55,7 +54,7 @@ static_assert(sizeof(ab_pair) == sizeof(A_tile) + sizeof(B_tile),
               "an interleaved pair must not introduce padding");
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_async_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_128x128_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -100,8 +99,6 @@ void gemm_async_kernel(const gemm_globals g, int M, int N, int K)
         const int cur = kb % S, nxt = (kb + 1) % S;
 
         kittens::sched::compiler_fence();
-        // The operand reads lead the fill: an async fill carries its own latency, so
-        // reading first gets the matrix op started sooner.
         kittens::load(A_reg, ring[cur].a, warp_off_a);
         kittens::load(B_reg, ring[cur].b, warp_off_b);
 
@@ -127,11 +124,11 @@ void gemm_async_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_async<0>();      // wait for data (async copy): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();         // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     // The C staging tile reuses the ring, so the request is the larger of the two, not the sum.
     const size_t load_lds  = S * sizeof(ab_pair);
@@ -143,15 +140,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_async: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "03_gemm_128x128: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_async");
+    gfx1250_gemm::require_k_blocks(g.K(), "03_gemm_128x128");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_async_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_128x128_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_async_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_128x128_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/04_gemm_256x256.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/04_gemm_256x256.cpp
@@ -1,22 +1,26 @@
 /**
- * @file gemm_128x128.cpp
- * @brief Rung 4 -- gemm_async with the macro tile doubled to 128x128.
+ * @file 04_gemm_256x256.cpp
+ * @brief Rung 04 -- 03_gemm_128x128 with the macro tile doubled again, to 256x256.
  *
  * Kernel Specification
- *   tile        128x128 macro, 32x32 per warp, 4x4 warps; BLOCK_K 32 = 1 x K_STEP 32
- *   occupancy   16 warps / 512 threads / 4 waves per SIMD; 2 workgroups per CU, register-bound
- *   registers   94 VGPR; 32 are accumulator (WARP_M*WARP_N/32), 26 SGPR
+ *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 32 = 1 x K_STEP 32
+ *   occupancy   16 warps / 512 threads / 4 waves per SIMD, one workgroup per CU
+ *   registers   220 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
+ *               (WARP_M*WARP_N/32), 26 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
- *   LDS         2 stages x 17 KB = 34 KB of 320 KB (10.6%)
+ *   LDS         2 stages x 34 KB = 68 KB of 320 KB (21.3%)
  *   sync        per K-block: 1 barrier (split), 1 LDS drain, 1 async drain
- *   intensity   64 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
+ *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * Arithmetic intensity for a square bf16 tile is M*N/(M+N) FLOP per byte, so it rises from 32 to
- * 64 across this step and the operand traffic per output element halves. That is worth about
- * 1.8x, the largest step on the ladder. The warp grid has to double with the tile, 2x2 -> 4x4, to
- * hold the warp tile at 32x32: a 2x2 grid on a 128x128 tile gives each warp four times the
- * accumulator and spills. Same BLOCK_K=32, two async-filled stages interleaved in one LDS
- * segment, plain split barrier, direct column-major epilogue. Uses only:
+ * Arithmetic intensity rises from 64 to 128 FLOP per byte, and each warp's output tile goes from
+ * 32x32 to 64x64, worth about 1.25x. This is the largest tile the register file allows at four
+ * waves per SIMD: the accumulator alone is 128 VGPRs of the 256 a lane gets there, and the kernel
+ * totals 220. Doubling the warp tile again needs 512 accumulator VGPRs, which fits only by dropping
+ * to one wave per SIMD for a 1024-VGPR budget. So the ladder stops growing the tile here and starts
+ * deepening it instead. Same BLOCK_K=32, 4x4 warps, two async-filled
+ * stages in one LDS segment, plain split barrier, direct column-major epilogue. A stage still
+ * covers exactly one matrix sub-step, so what overlaps here is the cross-K-block prefetch, one
+ * stage ahead. Uses only:
  *   - `kittens::load`       : cooperative `global_load_async_to_lds_b128` fill.
  *   - `kittens::sync::wait_async` : drain the async fill.
  *   - `kittens::sync::arrive/wait`: split workgroup barrier (-1).
@@ -29,8 +33,8 @@
 
 #include "kittens.cuh"
 
-constexpr int BLOCK_M     = 128;
-constexpr int BLOCK_N     = 128;
+constexpr int BLOCK_M     = 256;
+constexpr int BLOCK_N     = 256;
 constexpr int BLOCK_K     = 32;
 constexpr int K_STEP      = 32;
 constexpr int WARPS_M     = 4;
@@ -54,7 +58,7 @@ static_assert(sizeof(ab_pair) == sizeof(A_tile) + sizeof(B_tile),
               "an interleaved pair must not introduce padding");
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_128x128_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_256x256_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -124,11 +128,11 @@ void gemm_128x128_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_async<0>();      // wait for data (async copy): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();         // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     // The C staging tile reuses the ring, so the request is the larger of the two, not the sum.
     const size_t load_lds  = S * sizeof(ab_pair);
@@ -140,15 +144,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_128x128: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "04_gemm_256x256: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_128x128");
+    gfx1250_gemm::require_k_blocks(g.K(), "04_gemm_256x256");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_128x128_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_256x256_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_128x128_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_256x256_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/05_gemm_deepk.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/05_gemm_deepk.cpp
@@ -1,6 +1,6 @@
 /**
- * @file gemm_deepk.cpp
- * @brief Rung 6 -- gemm_256x256 with the LDS stage deepened, BLOCK_K 32 -> 128.
+ * @file 05_gemm_deepk.cpp
+ * @brief Rung 05 -- 04_gemm_256x256 with the LDS stage deepened, BLOCK_K 32 -> 128.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
@@ -153,11 +153,11 @@ void gemm_deepk_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_async<0>();      // wait for data (async copy): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();         // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* The C staging tile reuses the ring, so the request is the larger of the two, not the sum.
      * At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -170,15 +170,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_deepk: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "05_gemm_deepk: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_deepk");
+    gfx1250_gemm::require_k_blocks(g.K(), "05_gemm_deepk");
 
     hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_deepk_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_deepk_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_deepk_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/06_gemm_segment.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/06_gemm_segment.cpp
@@ -1,6 +1,6 @@
 /**
- * @file gemm_segment.cpp
- * @brief Rung 7 -- gemm_deepk with the operand rings separated into different LDS segments.
+ * @file 06_gemm_segment.cpp
+ * @brief Rung 06 -- 05_gemm_deepk with the operand rings separated into different LDS segments.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
@@ -158,11 +158,11 @@ void gemm_segment_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_async<0>();      // wait for data (async copy): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();         // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* The C staging tile reuses the operand rings, so the request is the larger of the two, not
      * the sum. At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -175,15 +175,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_segment: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "06_gemm_segment: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_segment");
+    gfx1250_gemm::require_k_blocks(g.K(), "06_gemm_segment");
 
     hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_segment_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_segment_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_segment_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/07_gemm_tdm.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/07_gemm_tdm.cpp
@@ -1,40 +1,33 @@
 /**
- * @file gemm_split_bar.cpp
- * @brief Rung 9 -- gemm_tdm with the workgroup barrier actually split.
+ * @file 07_gemm_tdm.cpp
+ * @brief Rung 07 -- 06_gemm_segment with the fill moved onto the hardware tile-DMA engine.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
  *   occupancy   16 warps / 512 threads / 4 waves per SIMD, one workgroup per CU
- *   registers   234 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
+ *   registers   222 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
  *               (WARP_M*WARP_N/32), 46 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
  *   LDS         2 stages x 136 KB = 272 KB of 320 KB (85%)
  *   sync        per K-block: 1 barrier (split), 4 LDS waits (3 partial, 1 full), 1 TDM drain
- *   window      the K-block's last mma_ABt issues between arrive() and wait()
+ *   window      empty: the K-block's last mma_ABt issues before arrive()
  *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * Every rung below closes the barrier the instant it opens it -- rungs 1 and 2 through the fused
- * `sync()`, rungs 3 to 8 by issuing `arrive()` and `wait()` back to back, which is the split API
- * spent as a fused barrier. Here the two halves are finally pulled apart and the K-block's last
- * matrix op is issued between them. What makes that legal is that the op reads registers only: a
- * wave is done with the LDS stage the moment its `ds_load`s drain, which is strictly before it is
- * done computing, so it can declare itself finished and keep working. A barrier costs skew rather
- * than instructions -- every wave that arrives early idles until the slowest one shows up -- and
- * this spends that idle time rather than shortening it. Sixteen `v_wmma` sit in the window, worth
- * about 5%.
- *
- * It fails silently. Nothing in the language holds the op inside the window: the compiler will
- * hoist it above the signal or sink it below the wait, and when it does the answers stay correct,
- * verification still passes, and the 5% is simply gone. The fences around the matrix op are what
- * pin it. Same 256x256 tile, BLOCK_K=128, 4x4 warps, two-stage TDM ring, segment-separated LDS,
- * direct column-major epilogue. Uses only:
+ * `tdm::load_async` is a descriptor-driven global -> LDS copy: one wave posts one descriptor where the
+ * async path had every lane issue its own transfer, so the waves stop spending issue slots on
+ * the fill entirely. That is worth about 1.35x. It also drags two things along, because the API
+ * requires them: the stage becomes one deep 256x128 panel instead of four sub-tiles, and the
+ * tail skip becomes a count=0 descriptor, since a TDM cannot be EXEC-masked. The barrier is
+ * plain: the K-block's last matrix op issues before the signal, so the signal-to-wait window is
+ * empty. Same 256x256 tile, BLOCK_K=128, 4x4 warps, two stages, segment-separated LDS, direct
+ * column-major epilogue. Uses only:
  *   - `kittens::tdm::load_async`         : descriptor-driven global -> LDS tile DMA.
  *   - `kittens::sync::wait_tdm`   : drain the tile DMA.
- *   - `kittens::sync::arrive/wait`: workgroup barrier (-1), in the split form.
+ *   - `kittens::sync::arrive/wait`: split workgroup barrier (-1).
  *   - `kittens::sync::wait_ds`    : partial and full LDS-read drains.
  *   - `kittens::load(rt,st,off)`  : shared -> register load (wide `ds_load_b128`).
  *   - `kittens::mma_ABt`          : 16x16x32 WMMA via the bf16 builtin.
- *   - `kittens::sched::compiler_fence` : hold the matrix op inside the signal-to-wait window.
+ *   - `kittens::sched::compiler_fence` : keep the post-wait loads below the barrier.
  *   - `kittens::store(gl,rt,idx)` : direct column-major epilogue.
  */
 
@@ -44,9 +37,6 @@ constexpr int BLOCK_M     = 256;
 constexpr int BLOCK_N     = 256;
 constexpr int BLOCK_K     = 128;
 constexpr int K_STEP      = 32;
-/* Four waves per SIMD is what the register file allows: at eight it cannot hold the
- * double-buffered operands plus the matrix op held in the window, and the kernel spills. Wave
- * count is co-designed with the split form rather than free to set on its own. */
 constexpr int WARPS_M     = 4;
 constexpr int WARPS_N     = 4;
 constexpr int WARP_M      = BLOCK_M / WARPS_M;
@@ -67,7 +57,7 @@ using A_deep = st_e<BLOCK_M, BLOCK_K>;
 using B_deep = st_e<BLOCK_N, BLOCK_K>;
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -104,7 +94,6 @@ void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
         if (wid == 1) kittens::tdm::load_async(B_st[slot], g.b, {0, 0, tile_n, kblock}, N, K, K, 0, count);
     };
 
-    // Split into a signal half and a wait half so real work can be placed between them.
     // Prologue: fill the ring ahead of the loop.
     #pragma unroll
     for (int s = 0; s < S - 1; ++s)
@@ -112,7 +101,7 @@ void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
 
     kittens::sync::wait_tdm<0>();                     // wait for data (TDM): stage 0 landed
     kittens::sched::compiler_fence();
-    kittens::sync::arrive(); kittens::sync::wait();   // wait for everyone (workgroup): no work to fill
+    kittens::sync::arrive(); kittens::sync::wait();   // wait for everyone (workgroup): stage 0 ready
     kittens::sched::compiler_fence();
 
     // Operands are double-buffered in registers: the matrix unit reads one buffer while the
@@ -135,9 +124,8 @@ void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
         const uint32_t cnt = (kb + 1 < k_blocks) ? 1u : 0u;
         issue_fill(nxt, fk, cnt);
 
-        /* Sub-steps 0 .. KS-2. The partial wait leaves DS_SUB loads in flight, which is
-         * sound because the LDS counter retires in order. The last sub-step is peeled out
-         * below because it hands the stage over. */
+        /* Sub-steps 0 .. KS-2. The wait is partial -- it lets DS_SUB loads stay in flight
+         * -- which is sound because the LDS counter retires in order. */
         #pragma unroll
         for (int si = 0; si < KS - 1; ++si) {
             const int c = si & 1, n = 1 - c;
@@ -148,19 +136,15 @@ void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
             mma_ABt(C_acc, A_reg[c], B_reg[c], C_acc);
         }
 
-        /* The stage handoff, in the split form. Both counters drain first: LDS says this wave
-         * is done with the current stage, TDM says the next has landed. The final matrix op is
-         * then the independent work between signalling and waiting -- independent because it
-         * reads registers only. The fences hold it inside the window; without them it is
-         * hoisted above the signal or sunk below the wait. */
+        /* The stage handoff. Both counters drain before the signal: LDS says this wave is
+         * done with the current stage, TDM says the next has landed. The final matrix op
+         * issues below the wait, so nothing covers the rendezvous. */
         constexpr int c_last = (KS - 1) & 1;
         kittens::sync::wait_ds<0>();       // wait for data (LDS): done reading the current stage
+        mma_ABt(C_acc, A_reg[c_last], B_reg[c_last], C_acc);
         kittens::sync::wait_tdm<S - 2>();  // wait for data (TDM): the next stage's fill has landed
         kittens::sched::compiler_fence();
         kittens::sync::arrive();           // wait for everyone (workgroup): publish next, protect this
-        kittens::sched::compiler_fence();
-        mma_ABt(C_acc, A_reg[c_last], B_reg[c_last], C_acc);   // 16 v_wmma inside the barrier window
-        kittens::sched::compiler_fence();
         kittens::sync::wait();
         kittens::sched::compiler_fence();
     }
@@ -169,11 +153,11 @@ void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_tdm<0>();          // wait for data (TDM): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();           // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* The C staging tile reuses the operand rings, so the request is the larger of the two, not
      * the sum. At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -186,15 +170,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_split_bar: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "07_gemm_tdm: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_split_bar");
+    gfx1250_gemm::require_k_blocks(g.K(), "07_gemm_tdm");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_split_bar_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_tdm_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_split_bar_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_tdm_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/08_gemm_split_bar.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/08_gemm_split_bar.cpp
@@ -1,33 +1,40 @@
 /**
- * @file gemm_tdm.cpp
- * @brief Rung 8 -- gemm_segment with the fill moved onto the hardware tile-DMA engine.
+ * @file 08_gemm_split_bar.cpp
+ * @brief Rung 08 -- 07_gemm_tdm with the workgroup barrier actually split.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
  *   occupancy   16 warps / 512 threads / 4 waves per SIMD, one workgroup per CU
- *   registers   222 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
+ *   registers   234 VGPR against a 256/lane budget (131072 / 512 threads); 128 are accumulator
  *               (WARP_M*WARP_N/32), 46 SGPR
  *   spills      none: 0 VGPR, 0 SGPR, 0 scratch
  *   LDS         2 stages x 136 KB = 272 KB of 320 KB (85%)
  *   sync        per K-block: 1 barrier (split), 4 LDS waits (3 partial, 1 full), 1 TDM drain
- *   window      empty: the K-block's last mma_ABt issues before arrive()
+ *   window      the K-block's last mma_ABt issues between arrive() and wait()
  *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * `tdm::load_async` is a descriptor-driven global -> LDS copy: one wave posts one descriptor where the
- * async path had every lane issue its own transfer, so the waves stop spending issue slots on
- * the fill entirely. That is worth about 1.39x. It also drags two things along, because the API
- * requires them: the stage becomes one deep 256x128 panel instead of four sub-tiles, and the
- * tail skip becomes a count=0 descriptor, since a TDM cannot be EXEC-masked. The barrier is
- * plain: the K-block's last matrix op issues before the signal, so the signal-to-wait window is
- * empty. Same 256x256 tile, BLOCK_K=128, 4x4 warps, two stages, segment-separated LDS, direct
- * column-major epilogue. Uses only:
+ * Every rung below closes the barrier the instant it opens it -- rungs 00 and 01 through the fused
+ * `sync()`, rungs 02 to 07 by issuing `arrive()` and `wait()` back to back, which is the split API
+ * spent as a fused barrier. Here the two halves are finally pulled apart and the K-block's last
+ * matrix op is issued between them. What makes that legal is that the op reads registers only: a
+ * wave is done with the LDS stage the moment its `ds_load`s drain, which is strictly before it is
+ * done computing, so it can declare itself finished and keep working. A barrier costs skew rather
+ * than instructions -- every wave that arrives early idles until the slowest one shows up -- and
+ * this spends that idle time rather than shortening it. Sixteen `v_wmma` sit in the window, worth
+ * about 4.3%.
+ *
+ * It fails silently. Nothing in the language holds the op inside the window: the compiler will
+ * hoist it above the signal or sink it below the wait, and when it does the answers stay correct,
+ * verification still passes, and the 5% is simply gone. The fences around the matrix op are what
+ * pin it. Same 256x256 tile, BLOCK_K=128, 4x4 warps, two-stage TDM ring, segment-separated LDS,
+ * direct column-major epilogue. Uses only:
  *   - `kittens::tdm::load_async`         : descriptor-driven global -> LDS tile DMA.
  *   - `kittens::sync::wait_tdm`   : drain the tile DMA.
- *   - `kittens::sync::arrive/wait`: split workgroup barrier (-1).
+ *   - `kittens::sync::arrive/wait`: workgroup barrier (-1), in the split form.
  *   - `kittens::sync::wait_ds`    : partial and full LDS-read drains.
  *   - `kittens::load(rt,st,off)`  : shared -> register load (wide `ds_load_b128`).
  *   - `kittens::mma_ABt`          : 16x16x32 WMMA via the bf16 builtin.
- *   - `kittens::sched::compiler_fence` : keep the post-wait loads below the barrier.
+ *   - `kittens::sched::compiler_fence` : hold the matrix op inside the signal-to-wait window.
  *   - `kittens::store(gl,rt,idx)` : direct column-major epilogue.
  */
 
@@ -37,6 +44,9 @@ constexpr int BLOCK_M     = 256;
 constexpr int BLOCK_N     = 256;
 constexpr int BLOCK_K     = 128;
 constexpr int K_STEP      = 32;
+/* Four waves per SIMD is what the register file allows: at eight it cannot hold the
+ * double-buffered operands plus the matrix op held in the window, and the kernel spills. Wave
+ * count is co-designed with the split form rather than free to set on its own. */
 constexpr int WARPS_M     = 4;
 constexpr int WARPS_N     = 4;
 constexpr int WARP_M      = BLOCK_M / WARPS_M;
@@ -57,7 +67,7 @@ using A_deep = st_e<BLOCK_M, BLOCK_K>;
 using B_deep = st_e<BLOCK_N, BLOCK_K>;
 
 __global__ __launch_bounds__(NUM_THREADS, 1)
-void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
+void gemm_split_bar_kernel(const gemm_globals g, int M, int N, int K)
 {
     extern __shared__ alignment_dummy __shm[];
     shared_allocator al(reinterpret_cast<int*>(&__shm[0]));
@@ -94,6 +104,7 @@ void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
         if (wid == 1) kittens::tdm::load_async(B_st[slot], g.b, {0, 0, tile_n, kblock}, N, K, K, 0, count);
     };
 
+    // Split into a signal half and a wait half so real work can be placed between them.
     // Prologue: fill the ring ahead of the loop.
     #pragma unroll
     for (int s = 0; s < S - 1; ++s)
@@ -101,7 +112,7 @@ void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
 
     kittens::sync::wait_tdm<0>();                     // wait for data (TDM): stage 0 landed
     kittens::sched::compiler_fence();
-    kittens::sync::arrive(); kittens::sync::wait();   // wait for everyone (workgroup): stage 0 ready
+    kittens::sync::arrive(); kittens::sync::wait();   // wait for everyone (workgroup): no work to fill
     kittens::sched::compiler_fence();
 
     // Operands are double-buffered in registers: the matrix unit reads one buffer while the
@@ -124,8 +135,9 @@ void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
         const uint32_t cnt = (kb + 1 < k_blocks) ? 1u : 0u;
         issue_fill(nxt, fk, cnt);
 
-        /* Sub-steps 0 .. KS-2. The wait is partial -- it lets DS_SUB loads stay in flight
-         * -- which is sound because the LDS counter retires in order. */
+        /* Sub-steps 0 .. KS-2. The partial wait leaves DS_SUB loads in flight, which is
+         * sound because the LDS counter retires in order. The last sub-step is peeled out
+         * below because it hands the stage over. */
         #pragma unroll
         for (int si = 0; si < KS - 1; ++si) {
             const int c = si & 1, n = 1 - c;
@@ -136,15 +148,19 @@ void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
             mma_ABt(C_acc, A_reg[c], B_reg[c], C_acc);
         }
 
-        /* The stage handoff. Both counters drain before the signal: LDS says this wave is
-         * done with the current stage, TDM says the next has landed. The final matrix op
-         * issues below the wait, so nothing covers the rendezvous. */
+        /* The stage handoff, in the split form. Both counters drain first: LDS says this wave
+         * is done with the current stage, TDM says the next has landed. The final matrix op is
+         * then the independent work between signalling and waiting -- independent because it
+         * reads registers only. The fences hold it inside the window; without them it is
+         * hoisted above the signal or sunk below the wait. */
         constexpr int c_last = (KS - 1) & 1;
         kittens::sync::wait_ds<0>();       // wait for data (LDS): done reading the current stage
-        mma_ABt(C_acc, A_reg[c_last], B_reg[c_last], C_acc);
         kittens::sync::wait_tdm<S - 2>();  // wait for data (TDM): the next stage's fill has landed
         kittens::sched::compiler_fence();
         kittens::sync::arrive();           // wait for everyone (workgroup): publish next, protect this
+        kittens::sched::compiler_fence();
+        mma_ABt(C_acc, A_reg[c_last], B_reg[c_last], C_acc);   // 16 v_wmma inside the barrier window
+        kittens::sched::compiler_fence();
         kittens::sync::wait();
         kittens::sched::compiler_fence();
     }
@@ -153,11 +169,11 @@ void gemm_tdm_kernel(const gemm_globals g, int M, int N, int K)
     kittens::sync::wait_tdm<0>();          // wait for data (TDM): no fill outlives the workgroup
     kittens::sync::wait_ds<0>();           // wait for data (LDS): nor any read of the ring
 
-    // Direct store: warp accumulator to bf16 in global C; `gemm_naive` has the transaction-size cost.
+    // Direct store: warp accumulator to bf16 in global C; rung 00 has the transaction-size cost.
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* The C staging tile reuses the operand rings, so the request is the larger of the two, not
      * the sum. At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -170,15 +186,16 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_tdm: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "08_gemm_split_bar: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_tdm");
+    gfx1250_gemm::require_k_blocks(g.K(), "08_gemm_split_bar");
 
-    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_tdm_kernel),
+    hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_split_bar_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
-    gemm_tdm_kernel<<<g.grid(), g.block(), mem_size, g.stream>>>(g, g.M(), g.N(), g.K());
+    gemm_split_bar_kernel<<<launch.grid, launch.block, mem_size, launch.stream>>>(
+        g, g.M(), g.N(), g.K());
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/09_gemm_wgc_multicast.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/09_gemm_wgc_multicast.cpp
@@ -1,6 +1,6 @@
 /**
- * @file gemm_wgc_multicast.cpp
- * @brief Rung 10 -- gemm_split_bar plus a workgroup cluster multicasting both operands.
+ * @file 09_gemm_wgc_multicast.cpp
+ * @brief Rung 09 -- 08_gemm_split_bar plus a workgroup cluster multicasting both operands.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
@@ -15,10 +15,10 @@
  *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
  * Sixteen workgroups form a 4x4 cluster and share each fetched panel four ways, which removes
- * 75% of the fill transactions and is worth about 5%. What it costs is a second rendezvous: the
+ * 75% of the fill transactions and is worth about 7.2%. What it costs is a second rendezvous: the
  * barrier grows a cluster half alongside the workgroup one, and the launch now has a shape
  * requirement, since a cluster only forms if the grid divides by the cluster dimension.
- * Everything else is `gemm_split_bar`: 256x256 macro tile, BLOCK_K=128 walked in four K_STEP=32
+ * Everything else is `08_gemm_split_bar`: 256x256 macro tile, BLOCK_K=128 walked in four K_STEP=32
  * sub-steps, 4x4 warps, a two-stage TDM-filled LDS ring, the barrier in its split form, and a
  * direct column-major epilogue. Uses only:
  *   - `kittens::tdm::load_async`         : descriptor-driven global -> LDS tile DMA, with multicast.
@@ -188,7 +188,7 @@ void gemm_wgc_multicast_kernel(const gemm_globals g, int M, int N, int K)
     kittens::store(g.c, C_acc, {0, 0, tile_m * WARPS_M + warp_r, tile_n * WARPS_N + warp_c});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* C is stored straight out of registers, so the LDS request is the operand ring alone.
      * At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -201,42 +201,30 @@ void dispatch(gemm_globals g)
      * wider accumulator shape lengthens the run. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_wgc_multicast: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "09_gemm_wgc_multicast: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_wgc_multicast");
+    gfx1250_gemm::require_k_blocks(g.K(), "09_gemm_wgc_multicast");
 
     hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_wgc_multicast_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
 
-    const dim3 grid = g.grid();
+    const dim3 grid = launch.grid;
 
     /* Refuse rather than launch without a cluster. The multicast masks name peers by cluster
      * position, so without the cluster they name workgroups that are not co-scheduled. */
     if (grid.x % CLUSTER_DIM != 0 || grid.y % CLUSTER_DIM != 0) {
-        printf("!! gemm_wgc_multicast: a %dx%d cluster needs grid.x and grid.y both divisible "
+        printf("!! 09_gemm_wgc_multicast: a %dx%d cluster needs grid.x and grid.y both divisible "
                "by %d; got %ux%u.\n", CLUSTER_DIM, CLUSTER_DIM, CLUSTER_DIM, grid.x, grid.y);
         return;
     }
 
-    hipLaunchConfig_t cfg = {};
-    cfg.gridDim          = grid;
-    cfg.blockDim         = g.block();
-    cfg.dynamicSmemBytes = mem_size;
-    cfg.stream           = g.stream;
-
-    hipLaunchAttribute attrs[1];
-    attrs[0].id               = hipLaunchAttributeClusterDimension;
-    attrs[0].val.clusterDim.x = CLUSTER_DIM;
-    attrs[0].val.clusterDim.y = CLUSTER_DIM;
-    attrs[0].val.clusterDim.z = 1;
-    cfg.attrs    = attrs;
-    cfg.numAttrs = 1;
-
-    const hipError_t e = hipLaunchKernelEx(&cfg, gemm_wgc_multicast_kernel, g, g.M(), g.N(), g.K());
+    hipLaunchKernelGGL(gemm_wgc_multicast_kernel, grid, launch.block, mem_size, launch.stream,
+                       g, g.M(), g.N(), g.K());
+    const hipError_t e = hipGetLastError();
     if (e != hipSuccess)
-        printf("!! gemm_wgc_multicast: cluster launch REJECTED: %s\n", hipGetErrorString(e));
+        printf("!! 09_gemm_wgc_multicast: cluster launch REJECTED: %s\n", hipGetErrorString(e));
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/10_gemm_epilogue.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/10_gemm_epilogue.cpp
@@ -1,7 +1,7 @@
 /**
- * @file gemm_epilogue.cpp
- * @brief Rung 11 -- staging C through LDS as a feature of the kernel rather than of the ops, and a
- *        wave that issues its matrix ops back to back.
+ * @file 10_gemm_epilogue.cpp
+ * @brief Rung 10 -- 09_gemm_wgc_multicast plus an LDS-staged C epilogue and a wave that issues
+ *        its matrix ops back to back.
  *
  * Kernel Specification
  *   tile        256x256 macro, 64x64 per warp, 4x4 warps; BLOCK_K 128 = 4 x K_STEP 32
@@ -17,14 +17,14 @@
  *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
  * The rungs below store C straight out of registers with `store(gl, rt, idx)`. This rung stages it
- * through LDS first, worth **+5.43%** over `gemm_wgc_multicast`, the kernel it derives from, against a
- * 0.91% floor -- a ratio of absolutes rather than a paired step. Both paths are contiguous per lane --
- * a col-layout accumulator into a column-major C always is -- so what staging buys is two other
- * things. It doubles the run, because a lane's direct store is stuck with the accumulator's 4-element
- * share (`buffer_store_b64`) while the staged stream assigns 8 elements per thread
- * (`global_store_b128`). And a warp's 32 lanes sit on 16 different columns, which in a column-major C
- * are a leading dimension apart, so the direct store lands as scattered per-column transactions;
- * letting four warps' rows meet in LDS turns those into one long stream.
+ * through LDS and also locks SIMD arbitration; together the fresh full-ladder step is **+7.32%
+ * [+7.20, +7.43] n=25** over `09_gemm_wgc_multicast`, above the campaign's 0.61% resolution floor.
+ * Both paths are contiguous per lane -- a col-layout accumulator into a column-major C always is --
+ * so what staging buys is two other things. It doubles the run, because a lane's direct store is
+ * stuck with the accumulator's 4-element share (`buffer_store_b64`) while the staged stream assigns
+ * 8 elements per thread (`global_store_b128`). And a warp's 32 lanes sit on 16 different columns,
+ * which in a column-major C are a leading dimension apart, so the direct store lands as scattered
+ * per-column transactions; letting four warps' rows meet in LDS turns those into one long stream.
  *
  * The kernel owns the drain-stage-drain-stream sequence itself rather than calling into an op that
  * hides the barriers: `store(st, rt)` decides the transpose from the two tiles' layouts with no global
@@ -33,10 +33,10 @@
  * one `ds_store_b128` per eight values -- the wide path, selected by the types rather than by an
  * overload on the global descriptor.
  *
- * The +5.43% is entirely rung 10 giving this up rather than this rung gaining anything. In a
- * same-session A/B, rung 10 reads 2468.7 TFLOP/s with a staged epilogue and 2349.2 with the direct
+ * A controlled same-session ablation attributes +5.43% to staging: rung 09 reads 2468.7 TFLOP/s
+ * with a staged epilogue and 2349.2 with the direct
  * store, while this kernel reads 2475.4 and 2472.1 across the same pair -- unchanged, as it must be,
- * since only rung 10 differs between the two arms. With both arms staging, the step is +0.27%.
+ * since only rung 09 differs between the two arms. With both arms staging, the step is +0.27%.
  *
  * The stream out is the plain `store(gl, st)`, by measurement rather than by default. `tdm::store_async`
  * works and this kernel can use it -- build with `-DE_TDM=1 -DE_PAD=256` -- and it does exactly what it
@@ -51,7 +51,7 @@
  * prologue, which is worth about +1.9% for a single scalar register write and no extra register.
  * The reasoning is at the call site.
  *
- * Everything else is `gemm_wgc_multicast` at the shape above: a two-stage TDM-filled LDS ring, the
+ * Everything else is `09_gemm_wgc_multicast` at the shape above: a two-stage TDM-filled LDS ring, the
  * split barrier, and a 4x4 cluster multicasting both operands. Uses only:
  *   - `kittens::sched::lock_simd` : clear the post-matrix-op arbitration stall for this wave.
  *   - `kittens::tdm::load_async`  : descriptor-driven global -> LDS tile DMA, with multicast.
@@ -259,7 +259,7 @@ void gemm_epilogue_kernel(const gemm_globals g, int M, int N, int K)
 #endif
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     const size_t load_lds  = S * (sizeof(A_deep) + sizeof(B_deep));
     const size_t store_lds = sizeof(C_col);
@@ -269,40 +269,28 @@ void dispatch(gemm_globals g)
      * the leading dimension is a multiple of 8. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_epilogue: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "10_gemm_epilogue: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_epilogue");
+    gfx1250_gemm::require_k_blocks(g.K(), "10_gemm_epilogue");
 
     hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_epilogue_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
 
-    const dim3 grid = g.grid();
+    const dim3 grid = launch.grid;
 
     if (grid.x % CLUSTER_DIM != 0 || grid.y % CLUSTER_DIM != 0) {
-        printf("!! gemm_epilogue: a %dx%d cluster needs grid.x and grid.y both divisible "
+        printf("!! 10_gemm_epilogue: a %dx%d cluster needs grid.x and grid.y both divisible "
                "by %d; got %ux%u.\n", CLUSTER_DIM, CLUSTER_DIM, CLUSTER_DIM, grid.x, grid.y);
         return;
     }
 
-    hipLaunchConfig_t cfg = {};
-    cfg.gridDim          = grid;
-    cfg.blockDim         = g.block();
-    cfg.dynamicSmemBytes = mem_size;
-    cfg.stream           = g.stream;
-
-    hipLaunchAttribute attrs[1];
-    attrs[0].id               = hipLaunchAttributeClusterDimension;
-    attrs[0].val.clusterDim.x = CLUSTER_DIM;
-    attrs[0].val.clusterDim.y = CLUSTER_DIM;
-    attrs[0].val.clusterDim.z = 1;
-    cfg.attrs    = attrs;
-    cfg.numAttrs = 1;
-
-    const hipError_t e = hipLaunchKernelEx(&cfg, gemm_epilogue_kernel, g, g.M(), g.N(), g.K());
+    hipLaunchKernelGGL(gemm_epilogue_kernel, grid, launch.block, mem_size, launch.stream,
+                       g, g.M(), g.N(), g.K());
+    const hipError_t e = hipGetLastError();
     if (e != hipSuccess)
-        printf("!! gemm_epilogue: cluster launch REJECTED: %s\n", hipGetErrorString(e));
+        printf("!! 10_gemm_epilogue: cluster launch REJECTED: %s\n", hipGetErrorString(e));
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/11_gemm_one_wave.cpp
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/11_gemm_one_wave.cpp
@@ -1,6 +1,6 @@
 /**
- * @file gemm_one_wave.cpp
- * @brief Rung 12 -- gemm_epilogue (rung 11) dropped to one wave per SIMD, with the software-
+ * @file 11_gemm_one_wave.cpp
+ * @brief Rung 11 -- 10_gemm_epilogue dropped to one wave per SIMD, with the software-
  *        pipelined operand feed on a pinned schedule that the drop requires.
  *
  * Kernel Specification
@@ -17,11 +17,11 @@
  *   pipeline    R = 3 register operand ring; 2 sub-steps primed ahead of the first matrix op
  *   intensity   128 FLOP per byte of global operand traffic, BM*BN/(BM+BN)
  *
- * Rungs 1 to 11 run four waves per SIMD. This one runs 2x2 warps, 128 threads, one wave. A lane's
+ * Rungs 00 to 10 run four waves per SIMD. This one runs 2x2 warps, 128 threads, one wave. A lane's
  * register budget is 131072 divided by the thread count, so taking threads from 512 to 128 takes a
  * lane from 256 registers to 1024.
  *
- * Those registers hold a 128x128 warp tile in place of rung 11's 64x64. The accumulator alone is
+ * Those registers hold a 128x128 warp tile in place of rung 10's 64x64. The accumulator alone is
  * 512 of the 1024, where 64x64 needs 128 of 256, so the wider tile only fits at this occupancy. It
  * also makes operands cheaper: a warp's LDS reads scale with its tile's perimeter and its matrix
  * ops with the area, so doubling both sides doubles the reads and quadruples the math. Each read
@@ -43,7 +43,7 @@
  * different 64 KB segments and the two reads do not contend. That is free at four waves, where a
  * barrier already separates them, and load-bearing here where they are adjacent.
  *
- * Uses only what rung 11 uses, plus a `kittens::sched::compiler_fence` around each sub-step's
+ * Uses only what rung 10 uses, plus a `kittens::sched::compiler_fence` around each sub-step's
  * matrix op.
  */
 
@@ -77,7 +77,7 @@ static_assert(NUM_WARPS == 4, "the one-wave-per-SIMD point: 4 warps, 128 threads
 using A_deep = st_e<BLOCK_M, BLOCK_K>;
 using B_deep = st_e<BLOCK_N, BLOCK_K>;
 
-/* Column-major C staging tile, as rung 11 introduced it. Here it is not a
+/* Column-major C staging tile, as rung 10 introduced it. Here it is not a
  * choice at all -- see the epilogue comment. */
 using C_col = kittens::st<elem_t, BLOCK_M, BLOCK_N,
                           kittens::ducks::st_shape::st_16x32_padded<128, 8>,
@@ -124,7 +124,7 @@ void gemm_one_wave_kernel(const gemm_globals g, int M, int N, int K)
                          + ds_loads_per_subblock<WARP_N>();
     static_assert(DS_SUB < 64, "the partial LDS wait must fit the 6-bit dscnt field");
 
-    /* Multicast delivery masks, as rung 10 sets them: a workgroup's id within the cluster is
+    /* Multicast delivery masks, as rung 09 sets them: a workgroup's id within the cluster is
      * cx + 4*cy, so the four sharing its A panel have the same cx and the four sharing its B panel
      * the same cy. A wrong ordering is a wrong answer. */
     const uint32_t cx = blockIdx.x & 3u;
@@ -190,7 +190,7 @@ void gemm_one_wave_kernel(const gemm_globals g, int M, int N, int K)
         }
 
         /* Stage handoff, in order: drain LDS, drain TDM, signal both barriers, the last matrix op,
-         * then wait on both. This is rung 9's split form. */
+         * then wait on both. This is rung 08's split form. */
         constexpr int c_last = (KS - 1) % R;
         kittens::sync::wait_ds<0>();               // wait for data (LDS): done reading this stage
         kittens::sync::wait_tdm<S - 2>();          // wait for data (TDM): the next stage has landed
@@ -226,7 +226,7 @@ void gemm_one_wave_kernel(const gemm_globals g, int M, int N, int K)
     kittens::store<NUM_THREADS>(g.c, c_st, {0, 0, tile_m, tile_n});
 }
 
-void dispatch(gemm_globals g)
+void dispatch(gemm_globals g, const launch_config& launch)
 {
     /* The C staging tile reuses the operand rings, so the request is the larger of the two, not the
      * sum. At 278,528 B of 327,680 B it also holds the kernel to one workgroup per CU. */
@@ -238,42 +238,30 @@ void dispatch(gemm_globals g)
      * leading dimension is a multiple of 8. */
     if (g.c.rows() % 8 != 0) {
         std::fprintf(stderr,
-            "gemm_one_wave: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
+            "11_gemm_one_wave: column-major C requires M %% 8 == 0 (got M=%d)\n", g.c.rows());
         std::abort();
     }
 
-    gfx1250_gemm::require_k_blocks(g.K(), "gemm_one_wave");
+    gfx1250_gemm::require_k_blocks(g.K(), "11_gemm_one_wave");
 
     hipFuncSetAttribute(reinterpret_cast<const void*>(gemm_one_wave_kernel),
                         hipFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(mem_size));
 
-    const dim3 grid = g.grid();
+    const dim3 grid = launch.grid;
 
     /* Refuse rather than launch without a cluster. The multicast masks name peers by cluster
      * position, so without the cluster they name workgroups that are not co-scheduled. */
     if (grid.x % CLUSTER_DIM != 0 || grid.y % CLUSTER_DIM != 0) {
-        printf("!! gemm_one_wave: a %dx%d cluster needs grid.x and grid.y both divisible "
+        printf("!! 11_gemm_one_wave: a %dx%d cluster needs grid.x and grid.y both divisible "
                "by %d; got %ux%u.\n", CLUSTER_DIM, CLUSTER_DIM, CLUSTER_DIM, grid.x, grid.y);
         return;
     }
 
-    hipLaunchConfig_t cfg = {};
-    cfg.gridDim          = grid;
-    cfg.blockDim         = g.block();
-    cfg.dynamicSmemBytes = mem_size;
-    cfg.stream           = g.stream;
-
-    hipLaunchAttribute attrs[1];
-    attrs[0].id               = hipLaunchAttributeClusterDimension;
-    attrs[0].val.clusterDim.x = CLUSTER_DIM;
-    attrs[0].val.clusterDim.y = CLUSTER_DIM;
-    attrs[0].val.clusterDim.z = 1;
-    cfg.attrs    = attrs;
-    cfg.numAttrs = 1;
-
-    const hipError_t e = hipLaunchKernelEx(&cfg, gemm_one_wave_kernel, g, g.M(), g.N(), g.K());
+    hipLaunchKernelGGL(gemm_one_wave_kernel, grid, launch.block, mem_size, launch.stream,
+                       g, g.M(), g.N(), g.K());
+    const hipError_t e = hipGetLastError();
     if (e != hipSuccess)
-        printf("!! gemm_one_wave: cluster launch REJECTED: %s\n", hipGetErrorString(e));
+        printf("!! 11_gemm_one_wave: cluster launch REJECTED: %s\n", hipGetErrorString(e));
 }
 
 #include "harness.h"

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/Makefile
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/Makefile
@@ -4,16 +4,17 @@
 # point it has: `test.py` checks it against torch.matmul and `gemm_ladder.py` times it. Arch flags
 # and the Python discovery (PY_INCLUDES, PY_LDFLAGS, PY_EXT_SUFFIX) come from the shared
 # kernels/common.mk via GPU_TARGET=UDNA1; the rules are local (CUSTOM_RULES=1) because common.mk
-# builds one TARGET and this directory builds thirteen, each with its own module name.
+# builds one TARGET and this directory builds twelve, each with its own module name.
 #
 # Invocation:
-#   make KERNEL=gemm_naive               # one module, `import gemm_naive`
-#   make ladder                          # all thirteen rungs (all-kernels is the same target)
+#   make KERNEL=00_gemm_naive            # one module, loaded as `00_gemm_naive`
+#   make ladder                          # all twelve rungs (all-kernels is the same target)
 #   make test                            # the rungs, then check every one vs torch.matmul
 #   make clean
 #
-# The three cluster kernels (`gemm_wgc_multicast`, `gemm_epilogue`, `gemm_one_wave`) need `__cluster_dims__` and `hipLaunchAttributeClusterDimension`.
-# ROCm 7.2.4 and earlier have neither and fail these four with a cascade that reads as
+# The three cluster kernels (`09_gemm_wgc_multicast`, `10_gemm_epilogue`, `11_gemm_one_wave`) use
+# static `__cluster_dims__`; their ordinary HIP launches pick up the required 4x4 cluster metadata.
+# ROCm 7.2.4 and earlier lack this support and fail these three with a cascade that reads as
 # `shared_allocator` errors; ROCm 7.15 (clang 23) supports both. The nine non-cluster
 # kernels build on ROCm 7.2+.
 
@@ -23,14 +24,14 @@ CUSTOM_RULES := 1
 # The twelve rungs, listed top down. Each is named for the one hardware or algorithmic feature it
 # adds to the rung below it, and the list is every kernel on disk: the ladder is a single chain that
 # ends at its fastest kernel. See README.md.
-LADDER := gemm_one_wave gemm_epilogue gemm_wgc_multicast gemm_split_bar \
-          gemm_tdm gemm_segment gemm_deepk gemm_256x256 gemm_128x128 gemm_async \
-          gemm_double_buf gemm_naive
+LADDER := 00_gemm_naive 01_gemm_double_buf 02_gemm_async 03_gemm_128x128 \
+          04_gemm_256x256 05_gemm_deepk 06_gemm_segment 07_gemm_tdm \
+          08_gemm_split_bar 09_gemm_wgc_multicast 10_gemm_epilogue 11_gemm_one_wave
 
 # KERNEL names the artifact and SRC the source it is built from, separately, so one source can be
-# built under a second name: `make KERNEL=nullctl SRC=gemm_epilogue.cpp` is how `gemm_ladder.py`
+# built under a second name: `make KERNEL=nullctl SRC=11_gemm_one_wave.cpp` is how `gemm_ladder.py`
 # builds its null control.
-KERNEL ?= gemm_naive
+KERNEL ?= 00_gemm_naive
 SRC    := $(KERNEL).cpp
 
 include ../../../../common.mk
@@ -51,7 +52,7 @@ $(PYEXT): $(SRC) $(LOCAL_HEADERS) $(TK_HEADERS)
 	$(HIPCXX) $(HIPFLAGS) $(ICPPFLAGS) $(PY_INCLUDES) $(PY_LDFLAGS) -shared -fPIC \
 		-DHARNESS_PYEXT -DHK_PYEXT_NAME=$(KERNEL) $(SRC) -o $(PYEXT)
 
-# Everything on disk, so a toolchain or header change is checked against all 13 kernels.
+# Everything on disk, so a toolchain or header change is checked against all 12 kernels.
 # `all-kernels` is kept as an alias because scripts and docs name it.
 ladder all-kernels:
 	@for k in $(LADDER); do $(MAKE) KERNEL=$$k || exit 1; done

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/README.md
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/README.md
@@ -31,12 +31,13 @@ requests.
 
 ## Synchronization
 
-The rungs collectively use ten sync calls, which is a lot to meet at once -- but no rung meets more
-than one new one. Reading upward, `gemm_naive` and `gemm_double_buf` use only the full barrier
-`sync::sync`. `gemm_async` splits it into `arrive`/`wait` and adds `wait_async`, because the fill is
-now a copy engine that has to be waited on separately. `gemm_tdm` swaps that engine, and with it
-`wait_async` for `wait_tdm`. `gemm_wgc_multicast` adds the cluster barrier. `gemm_one_wave` adds no
-new primitive at all -- it only wraps the ones already there in `sched::compiler_fence`.
+The rungs collectively use eleven sync calls, which is a lot to meet at once -- but no rung meets
+more than one new one. Reading upward, `00_gemm_naive` and `01_gemm_double_buf` use the full barrier
+`sync::sync` and `wait_load` for their explicit GL -> RT -> ST path. `02_gemm_async` splits the
+barrier into `arrive`/`wait` and adds `wait_async`, because the fill is now a copy engine that has to
+be waited on separately. `07_gemm_tdm` swaps that engine, and with it `wait_async` for `wait_tdm`.
+`09_gemm_wgc_multicast` adds the cluster barrier. `11_gemm_one_wave` adds no new primitive at all --
+it only wraps the ones already there in `sched::compiler_fence`.
 
 Each call in a kernel is labelled with the job it does and the resource it does it on: `wait for
 data (LDS)`, `wait for data (TDM)`, `wait for everyone (workgroup)`, and so on. The two jobs are
@@ -56,8 +57,8 @@ intensity -- so the per-kernel facts sit next to the code rather than here.
 ```
 make all-kernels                                    # 12 pybind11 modules, no executables
 python3 test.py                                     # every rung, four shapes, against torch.matmul
-./gemm_ladder.py -r 25 -i 100                       # the table above
-./gemm_ladder.py -r 25 -i 100 --torch gemm_tdm gemm_one_wave
+./gemm_ladder.py -r 25 -i 100 --json-out results.json
+./gemm_ladder.py -r 25 -i 100 --torch 07_gemm_tdm 11_gemm_one_wave
 ```
 
 Rungs are positional and default to the whole ladder. Each cell is 500 warmup iterations then 100
@@ -68,10 +69,12 @@ ladder. Set `HIP_VISIBLE_DEVICES` to pick a card.
 
 ## Build
 
-The kernels target `gfx1250`. `gemm_wgc_multicast`, `gemm_epilogue` and `gemm_one_wave` use `__cluster_dims__` and the `hipLaunchAttributeClusterDimension` launch
-attribute; ROCm 7.2.4 and earlier have neither and fail those three with a cascade of errors that
-read as `shared_allocator` problems. Those three need **ROCm 7.15 (clang 23)**; the other nine build
-on ROCm 7.2+. Correctness needs PyTorch with gfx1250 support, which is **torch 2.11.0+rocm7.14.0**.
+The kernels target `gfx1250`. `09_gemm_wgc_multicast`, `10_gemm_epilogue` and
+`11_gemm_one_wave` use static `__cluster_dims__`; ordinary HIP launches pick up their required
+4x4 cluster metadata. ROCm 7.2.4 and earlier lack this support and fail those three with a cascade
+that reads as `shared_allocator` problems. Those three need **ROCm 7.15 (clang 23)**; the other nine
+build on ROCm 7.2+. Correctness needs PyTorch with gfx1250 support, which is
+**torch 2.11.0+rocm7.14.0**.
 
 ```
 pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ \

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/common.h
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/common.h
@@ -77,12 +77,23 @@ __device__ __host__ constexpr int ds_loads_per_subblock() { return (WARP_DIM / 1
 struct gemm_globals {
     gl_e a, b;
     gl_c c;
-    hipStream_t stream;
     int M() const { return a.rows(); }
     int N() const { return c.cols(); }
     int K() const { return a.cols(); }
-    dim3 grid()  const { return dim3(M() / BLOCK_M, N() / BLOCK_N); }
-    dim3 block() const { return dim3(NUM_THREADS); }
+};
+
+/* Host-only launch state stays beside, never inside, the object copied into the kernel argument
+ * buffer. A dispatch may compute its own LDS byte count when it has a nonstandard allocation. */
+struct launch_config {
+    hipStream_t stream;
+    dim3 grid;
+    dim3 block;
+
+    explicit launch_config(const gemm_globals& g, hipStream_t launch_stream = 0)
+        : stream(launch_stream),
+          grid(g.M() / BLOCK_M, g.N() / BLOCK_N),
+          block(NUM_THREADS) {}
+
     template <int STAGES = 2>
     size_t dynamic_shared_memory() const { return STAGES * (sizeof(A_tile) + sizeof(B_tile)); }
 };

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/gemm_ladder.py
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/gemm_ladder.py
@@ -12,7 +12,9 @@ same module object in the same process that then gets timed.
 """
 
 import argparse
+import datetime
 import importlib
+import json
 import socket
 import statistics
 import subprocess
@@ -29,9 +31,10 @@ from utils import compare, gemm_reference, init_c, init_uniform
 # Worst to best, and every kernel on disk: the ladder is a single chain in which each rung adds one
 # feature to the rung below, ending at the fastest kernel. So each step in the table below is a
 # paired delta over that rung's own parent.
-LADDER = ["gemm_naive", "gemm_double_buf", "gemm_async", "gemm_128x128", "gemm_256x256",
-          "gemm_deepk", "gemm_segment", "gemm_tdm", "gemm_split_bar", "gemm_wgc_multicast",
-          "gemm_epilogue", "gemm_one_wave"]
+LADDER = ["00_gemm_naive", "01_gemm_double_buf", "02_gemm_async", "03_gemm_128x128",
+          "04_gemm_256x256", "05_gemm_deepk", "06_gemm_segment", "07_gemm_tdm",
+          "08_gemm_split_bar", "09_gemm_wgc_multicast", "10_gemm_epilogue",
+          "11_gemm_one_wave"]
 
 HERE = Path(__file__).resolve().parent
 
@@ -45,7 +48,6 @@ FLUSH_MB = 512
 # 95% two-sided t, by degrees of freedom; 1.96 once n is large enough not to matter.
 T95 = {1: 12.71, 2: 4.30, 3: 3.18, 4: 2.78, 5: 2.57, 6: 2.45, 7: 2.36, 8: 2.31, 9: 2.26,
        10: 2.23, 12: 2.18, 15: 2.13, 19: 2.09, 20: 2.09, 25: 2.06, 29: 2.05}
-
 
 def build(arms, nullctl):
     """One module per arm, through the Makefile so the flags live in one place."""
@@ -134,6 +136,7 @@ def ci95(xs):
 
 
 def main():
+    started_utc = datetime.datetime.now(datetime.timezone.utc).isoformat()
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("rungs", nargs="*", default=LADDER,
@@ -147,6 +150,8 @@ def main():
                    help="skip the null control, and with it this campaign's resolution floor")
     p.add_argument("--torch", action="store_true",
                    help="time torch.matmul as a baseline arm, rotated alongside the rungs")
+    p.add_argument("--json-out", type=Path,
+                   help="write protocol metadata and every raw round to this JSON file")
     a = p.parse_args()
 
     shape = [int(x) for x in a.shape.split()]
@@ -186,22 +191,28 @@ def main():
     print(f"\n{socket.gethostname()}  {a.shape}  iters={a.iters}  rounds={a.rounds}")
     print(f"correctness: all {len(mods)} arms verified bad=0 against torch.matmul at {a.shape} "
           f"before timing began; the cells below report timing only\n")
-    print(f"{'#':>3}  {'rung':<17} {'TFLOP/s':>9} {'sd':>7} {'n':>3}   adds over the rung below")
+    print(f"{'#':>3}  {'rung':<22} {'TFLOP/s':>9} {'sd':>7} {'n':>3}   adds over the rung below")
     prev = None
-    for i, arm in enumerate(arms, 1):
+    summaries = {}
+    for i, arm in enumerate(arms):
         if not vals[arm]:
-            print(f"{i:>3}  {arm:<17} {'-':>9} {'-':>7} {0:>3}   NO CELLS")
+            print(f"{i:>3}  {arm:<22} {'-':>9} {'-':>7} {0:>3}   NO CELLS")
             prev = arm
             continue
         mean, sd, _, _ = ci95(vals[arm])
         step = ""
+        step_stats = None
         if prev:
             d = [100 * (rounds[r][arm] - rounds[r][prev]) / rounds[r][prev]
                  for r in rounds if arm in rounds[r] and prev in rounds[r]]
             if len(d) > 1:
                 dm, dsd, lo, hi = ci95(d)
                 step = f"{dm:+.2f}% [{lo:+.2f}, {hi:+.2f}] n={len(d)}"
-        print(f"{i:>3}  {arm:<17} {mean:>9.1f} {100 * sd / mean:>6.2f}% {len(vals[arm]):>3}   "
+                step_stats = {"mean_pct": dm, "sd_pct": dsd, "ci95_low_pct": lo,
+                              "ci95_high_pct": hi, "n": len(d)}
+        summaries[arm] = {"mean_tflops": mean, "sd_tflops": sd, "n": len(vals[arm]),
+                          "step_over_parent": step_stats}
+        print(f"{i:>3}  {arm:<22} {mean:>9.1f} {100 * sd / mean:>6.2f}% {len(vals[arm]):>3}   "
               f"{step}")
         prev = arm
 
@@ -211,11 +222,14 @@ def main():
         print(f"\ntorch.matmul baseline: {tm:.1f} TFLOP/s sd {100 * tsd / tm:.2f}% "
               f"n={len(vals[TORCH_ARM])}  ->  {arms[-1]} is {top / tm:.1f}x it")
 
+    null_stats = None
     if not a.no_null and vals["nullctl"]:
         d = [100 * (rounds[r]["nullctl"] - rounds[r][arms[-1]]) / rounds[r][arms[-1]]
              for r in rounds if "nullctl" in rounds[r] and arms[-1] in rounds[r]]
         if len(d) > 1:
             dm, dsd, _, _ = ci95(d)
+            null_stats = {"mean_delta_pct": dm, "sd_pct": dsd, "n": len(d),
+                          "resolution_pct": abs(dm) + 2 * dsd}
             print(f"\nnull control ({arms[-1]} built twice): {dm:+.3f}% sd {dsd:.3f} n={len(d)}"
                   f"  ->  resolution {abs(dm) + 2 * dsd:.2f}%")
 
@@ -223,6 +237,27 @@ def main():
         print(f"\n{len(dropped)} cell(s) dropped:")
         for r, arm, st in dropped:
             print(f"  round {r + 1} {arm}: {st}")
+
+    if a.json_out:
+        payload = {
+            "host": socket.gethostname(),
+            "started_utc": started_utc,
+            "finished_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "shape": {"m": m, "n": n, "k": k},
+            "protocol": {"warmups_per_cell": WARMUP, "measured_iters_per_cell": a.iters,
+                         "rounds": a.rounds, "order_rotation": True,
+                         "cache_flush_mb": FLUSH_MB, "seed": 0,
+                         "correctness_gate": "torch.matmul before timing"},
+            "device": {"gcn_arch": torch.cuda.get_device_properties(0).gcnArchName,
+                       "torch": torch.__version__},
+            "arms": arms,
+            "raw_rounds_tflops": rounds,
+            "summaries": summaries,
+            "null_control": null_stats,
+            "dropped": [{"round": r, "arm": arm, "status": st} for r, arm, st in dropped],
+        }
+        a.json_out.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        print(f"\nwrote raw results: {a.json_out}")
 
 
 if __name__ == "__main__":

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/harness.h
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/harness.h
@@ -2,7 +2,7 @@
  * @file harness.h
  * @brief Host entry point for the gfx1250 GEMM ladder.
  *
- * Every rung defines `dispatch(gemm_globals)` and includes this at the end of the file. Under
+ * Every rung defines `dispatch(gemm_globals, launch_config)` and includes this at the end of the file. Under
  * `-DHARNESS_PYEXT` that becomes a pybind11 module exporting `dispatch` for correctness checks and
  * `bench` for timing (see `pyext.h`). It is the only entry point a rung has, so every rung is
  * reached from Python: `test.py` is the correctness gate and `gemm_ladder.py` is the benchmark.
@@ -107,10 +107,12 @@ struct hk_timing {
     double spread_pct() const { return 100.0 * (ms_max - ms_min) / ms_per; }
 };
 
-static hk_timing hk_run_protocol(gfx1250_gemm::gemm_globals& g, int measured)
+static hk_timing hk_run_protocol(gfx1250_gemm::gemm_globals& g,
+                                 const gfx1250_gemm::launch_config& launch,
+                                 int measured)
 {
     if (measured <= 0) measured = HK_MEASURED_ITERS;
-    const hipStream_t stream = g.stream;
+    const hipStream_t stream = launch.stream;
 
     int dev = 0;
     HIP_OK(hipGetDevice(&dev));
@@ -120,7 +122,10 @@ static hk_timing hk_run_protocol(gfx1250_gemm::gemm_globals& g, int measured)
     cache_flusher flusher;
     flusher.init(props);
 
-    for (int i = 0; i < HK_WARMUP_ITERS; ++i) { flusher.run(stream); dispatch(g); }
+    for (int i = 0; i < HK_WARMUP_ITERS; ++i) {
+        flusher.run(stream);
+        dispatch(g, launch);
+    }
     HIP_OK(hipDeviceSynchronize());
 
     std::vector<hipEvent_t> ev_beg(measured), ev_end(measured);
@@ -131,7 +136,7 @@ static hk_timing hk_run_protocol(gfx1250_gemm::gemm_globals& g, int measured)
     for (int i = 0; i < measured; ++i) {
         flusher.run(stream);
         HIP_OK(hipEventRecord(ev_beg[i], stream));
-        dispatch(g);
+        dispatch(g, launch);
         HIP_OK(hipEventRecord(ev_end[i], stream));
     }
     HIP_OK(hipEventSynchronize(ev_end[measured - 1]));

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/pyext.h
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/pyext.h
@@ -4,8 +4,9 @@
  *
  * Included by `harness.h` under `-DHARNESS_PYEXT`, once per rung: each rung declares its own tile
  * geometry before including `common.h` and each names its entry point `dispatch`, so one module
- * cannot serve all thirteen. The module's name must match the .so basename, so both come from
- * `-DHK_PYEXT_NAME` and `make KERNEL=gemm_naive` gives Python `import gemm_naive`.
+ * cannot serve all twelve. The module's name must match the .so basename, so both come from
+ * `-DHK_PYEXT_NAME`; `make KERNEL=00_gemm_naive` builds the dynamically imported
+ * `00_gemm_naive` module.
  *
  * The tensor contract, which is the whole of what is easy to get wrong here because getting it
  * wrong produces a wrong answer rather than an error:
@@ -132,11 +133,7 @@ static gfx1250_gemm::gemm_globals make_globals(const pyb::object& a_obj,
     gfx1250_gemm::gl_c c_gl(reinterpret_cast<dev_elem*>(c.ptr),
                             size_t(1), size_t(1), size_t(M), size_t(N));
 
-    /* The null stream, which is also torch's default. A caller can be on another one and this
-     * module cannot read torch's current stream without linking libtorch, so both exports
-     * synchronise the whole device around the launch: before, so the operands are written; after,
-     * so `c` is readable by torch on return. */
-    return gfx1250_gemm::gemm_globals{a_gl, b_gl, c_gl, /*stream=*/ 0};
+    return gfx1250_gemm::gemm_globals{a_gl, b_gl, c_gl};
 }
 
 static void check_launch(const char* what)
@@ -149,8 +146,9 @@ static void check_launch(const char* what)
 static void py_dispatch(const pyb::object& a, const pyb::object& b, const pyb::object& c)
 {
     gfx1250_gemm::gemm_globals g = make_globals(a, b, c);
+    const gfx1250_gemm::launch_config launch(g, /*stream=*/ 0);
     HIP_OK(hipDeviceSynchronize());
-    dispatch(g);
+    dispatch(g, launch);
     check_launch("dispatch");
     HIP_OK(hipDeviceSynchronize());
 }
@@ -159,9 +157,10 @@ static pyb::dict py_bench(const pyb::object& a, const pyb::object& b, const pyb:
                           int iters)
 {
     gfx1250_gemm::gemm_globals g = make_globals(a, b, c);
+    const gfx1250_gemm::launch_config launch(g, /*stream=*/ 0);
     const int M = g.M(), N = g.N(), K = g.K();
     HIP_OK(hipDeviceSynchronize());
-    const hk_timing t = hk_run_protocol(g, iters);
+    const hk_timing t = hk_run_protocol(g, launch, iters);
     check_launch("bench");
 
     pyb::dict d;

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/test.py
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/test.py
@@ -5,8 +5,8 @@ This is the ladder's correctness gate: every rung against `torch.matmul` at four
 pybind11 module each one builds. There is no CPU reference in the tree.
 
     make all-kernels && python3 test.py               # every rung, every shape
-    python3 test.py --rung gemm_epilogue              # one rung
-    python3 test.py --rung gemm_epilogue -s "8192 8192 8192" --terse
+    python3 test.py --rung 10_gemm_epilogue              # one rung
+    python3 test.py --rung 10_gemm_epilogue -s "8192 8192 8192" --terse
 
 `--terse` prints one `bad=<count>` line per cell and exits non-zero if any rung fails.
 
@@ -27,7 +27,7 @@ def main():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
     p.add_argument("--rung", action="append",
-                   help="rung to check; repeatable. Default is all thirteen.")
+                   help="rung to check; repeatable. Default is all twelve.")
     p.add_argument("-s", "--shape", action="append",
                    help='"M N K"; repeatable. Default is the four shapes in utils.SHAPES.')
     p.add_argument("--terse", action="store_true",
@@ -55,7 +55,7 @@ def main():
         print(f"device: {torch.cuda.get_device_properties(0).gcnArchName}  "
               f"torch {torch.__version__}")
         print_title("gfx1250 bf16 GEMM ladder vs torch", 78)
-        print(f"{'rung':<19} {'shape':<20} {'bad':>10} {'max_err':>9} {'mean_err':>9} "
+        print(f"{'rung':<24} {'shape':<20} {'bad':>10} {'max_err':>9} {'mean_err':>9} "
               f"{'gate':>7}  ok")
 
     failures = 0
@@ -74,11 +74,11 @@ def main():
                       f"max_abs_err={st['max_abs_err']:.4f} "
                       f"{'OK' if ok else 'FAIL'}", flush=True)
             else:
-                print(f"{r:<19} {f'{m}x{n}x{k}':<20} {st['bad']:>4}/{st['n']:<10} "
+                print(f"{r:<24} {f'{m}x{n}x{k}':<20} {st['bad']:>4}/{st['n']:<10} "
                       f"{st['max_abs_err']:>8.4f} {st['mean_abs_err']:>9.4f} "
                       f"{st['atol']:>7.3f}  {'PASS' if ok else 'FAIL'}", flush=True)
                 if not ok:
-                    print(f"{'':<19} nonfinite={st['nonfinite']} "
+                    print(f"{'':<24} nonfinite={st['nonfinite']} "
                           f"max|ref|={st['max_ref_abs']:.1f}")
         del operand_a, operand_b, ref
         torch.cuda.empty_cache()

--- a/kernels/udna1/gemm/bf16fp32/gfx1250/utils.py
+++ b/kernels/udna1/gemm/bf16fp32/gfx1250/utils.py
@@ -12,12 +12,13 @@ DTYPE = torch.bfloat16
 DEVICE = "cuda:0"
 
 # Every kernel on disk, worst to best, which is also the chain `gemm_ladder.py` walks.
-RUNGS = ["gemm_naive", "gemm_double_buf", "gemm_async", "gemm_128x128", "gemm_256x256",
-         "gemm_deepk", "gemm_segment", "gemm_tdm", "gemm_split_bar", "gemm_wgc_multicast",
-         "gemm_epilogue", "gemm_one_wave"]
+RUNGS = ["00_gemm_naive", "01_gemm_double_buf", "02_gemm_async", "03_gemm_128x128",
+         "04_gemm_256x256", "05_gemm_deepk", "06_gemm_segment", "07_gemm_tdm",
+         "08_gemm_split_bar", "09_gemm_wgc_multicast", "10_gemm_epilogue",
+         "11_gemm_one_wave"]
 
-# Legal for all thirteen rungs at once, so a failure is about the rung and not the shape. The
-# binding constraint is the four cluster rungs: they launch a 4x4 cluster over a grid of
+# Legal for all twelve rungs at once, so a failure is about the rung and not the shape. The
+# binding constraint is the three cluster rungs: they launch a 4x4 cluster over a grid of
 # (M/256, N/256) workgroups and refuse a grid that is not a multiple of 4 in both axes, which makes
 # M and N multiples of 1024. K must be a multiple of the deepest BLOCK_K, 128. At least one shape
 # has to be non-square, because a layout error in C is invisible at M == N -- a transposed output


### PR DESCRIPTION
1. Rename so the rung number is in the filename @willhu-jpg 
2. Remove unused tma_desc
3. Restore gl -> rt -> st path for the naive first two rungs
4. Remove redundant cluster runtime launch configs
5. Separate launch and gemm parameters (useful for other works)